### PR TITLE
feat: shopping list product catalog, structured add, voice+LLM input

### DIFF
--- a/worldofmag/prisma/migrations/0003_product_catalog_and_config/migration.sql
+++ b/worldofmag/prisma/migrations/0003_product_catalog_and_config/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'Other',
+    "defaultUnit" TEXT,
+    "useCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT,
+    "teamId" TEXT,
+
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Config" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Config_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Config_key_key" ON "Config"("key");
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/worldofmag/prisma/schema.prisma
+++ b/worldofmag/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   sentInvitations   TeamInvitation[] @relation("InvitedBy")
   receivedInvitations TeamInvitation[] @relation("InvitedUser")
   ownedLists        ShoppingList[]
+  products          Product[]
 }
 
 model Account {
@@ -83,6 +84,7 @@ model Team {
   members     TeamMember[]
   invitations TeamInvitation[]
   lists       ShoppingList[]   @relation("TeamLists")
+  products    Product[]
 }
 
 model TeamMember {
@@ -150,5 +152,32 @@ model ItemHistory {
   category  String
   unit      String?
   useCount  Int      @default(1)
+  updatedAt DateTime @updatedAt
+}
+
+// ─── Product Catalog ──────────────────────────────────────────────────────
+
+model Product {
+  id          String   @id @default(cuid())
+  name        String
+  category    String   @default("Other")
+  defaultUnit String?
+  useCount    Int      @default(1)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  // userId=null AND teamId=null → global/seed product visible to everyone
+  userId      String?
+  teamId      String?
+
+  user User? @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team Team? @relation(fields: [teamId], references: [id], onDelete: Cascade)
+}
+
+// ─── System Config ────────────────────────────────────────────────────────
+
+model Config {
+  id        String   @id @default(cuid())
+  key       String   @unique
+  value     String
   updatedAt DateTime @updatedAt
 }

--- a/worldofmag/prisma/seed.ts
+++ b/worldofmag/prisma/seed.ts
@@ -3,30 +3,86 @@ import { categorize } from "../src/lib/categorize";
 
 const prisma = new PrismaClient();
 
-const COMMON_ITEMS = [
+// name → defaultUnit (null = no default unit, like "szt" implied)
+const COMMON_ITEMS: Array<{ name: string; unit?: string }> = [
   // Produce
-  "jabłka", "banany", "pomidory", "ogórki", "marchew", "ziemniaki", "cebula",
-  "czosnek", "papryka", "szpinak", "sałata", "brokuł", "kapusta", "por",
-  "cytryna", "awokado", "gruszki", "śliwki", "winogrona",
+  { name: "jabłka", unit: "kg" },
+  { name: "banany", unit: "kg" },
+  { name: "pomidory", unit: "kg" },
+  { name: "ogórki", unit: "szt" },
+  { name: "marchew", unit: "kg" },
+  { name: "ziemniaki", unit: "kg" },
+  { name: "cebula", unit: "kg" },
+  { name: "czosnek", unit: "szt" },
+  { name: "papryka", unit: "szt" },
+  { name: "szpinak", unit: "op" },
+  { name: "sałata", unit: "szt" },
+  { name: "brokuł", unit: "szt" },
+  { name: "kapusta", unit: "szt" },
+  { name: "por", unit: "szt" },
+  { name: "cytryna", unit: "szt" },
+  { name: "awokado", unit: "szt" },
+  { name: "gruszki", unit: "kg" },
+  { name: "śliwki", unit: "kg" },
+  { name: "winogrona", unit: "kg" },
   // Dairy
-  "mleko", "masło", "ser żółty", "jogurt naturalny", "jajka", "śmietana",
-  "twaróg", "kefir", "mozzarella", "serek wiejski",
+  { name: "mleko", unit: "l" },
+  { name: "masło", unit: "szt" },
+  { name: "ser żółty", unit: "dkg" },
+  { name: "jogurt naturalny", unit: "szt" },
+  { name: "jajka", unit: "szt" },
+  { name: "śmietana", unit: "szt" },
+  { name: "twaróg", unit: "szt" },
+  { name: "kefir", unit: "szt" },
+  { name: "mozzarella", unit: "szt" },
+  { name: "serek wiejski", unit: "szt" },
   // Meat
-  "kurczak", "mielone wołowe", "boczek", "szynka", "parówki", "schab",
-  "łosoś", "tuńczyk w puszce", "krewetki",
+  { name: "kurczak", unit: "kg" },
+  { name: "mielone wołowe", unit: "kg" },
+  { name: "boczek", unit: "dkg" },
+  { name: "szynka", unit: "dkg" },
+  { name: "parówki", unit: "op" },
+  { name: "schab", unit: "kg" },
+  { name: "łosoś", unit: "dkg" },
+  { name: "tuńczyk w puszce", unit: "szt" },
+  { name: "krewetki", unit: "g" },
   // Bakery
-  "chleb", "bułki", "bagietka", "chleb żytni",
+  { name: "chleb", unit: "szt" },
+  { name: "bułki", unit: "szt" },
+  { name: "bagietka", unit: "szt" },
+  { name: "chleb żytni", unit: "szt" },
   // Dry
-  "makaron spaghetti", "ryż", "mąka pszenna", "cukier", "sól", "płatki owsiane",
-  "kasza gryczana", "soczewica czerwona", "fasola biała",
+  { name: "makaron spaghetti", unit: "op" },
+  { name: "ryż", unit: "kg" },
+  { name: "mąka pszenna", unit: "kg" },
+  { name: "cukier", unit: "kg" },
+  { name: "sól", unit: "szt" },
+  { name: "płatki owsiane", unit: "op" },
+  { name: "kasza gryczana", unit: "op" },
+  { name: "soczewica czerwona", unit: "op" },
+  { name: "fasola biała", unit: "op" },
   // Drinks
-  "woda mineralna", "sok pomarańczowy", "kawa", "herbata", "piwo",
+  { name: "woda mineralna", unit: "l" },
+  { name: "sok pomarańczowy", unit: "l" },
+  { name: "kawa", unit: "op" },
+  { name: "herbata", unit: "op" },
+  { name: "piwo", unit: "szt" },
   // Snacks
-  "czekolada gorzka", "chipsy", "orzechy", "miód",
+  { name: "czekolada gorzka", unit: "szt" },
+  { name: "chipsy", unit: "op" },
+  { name: "orzechy", unit: "g" },
+  { name: "miód", unit: "słoik" },
   // Condiments
-  "oliwa z oliwek", "ketchup", "musztarda", "sos sojowy",
+  { name: "oliwa z oliwek", unit: "butelka" },
+  { name: "ketchup", unit: "szt" },
+  { name: "musztarda", unit: "szt" },
+  { name: "sos sojowy", unit: "butelka" },
   // Cleaning
-  "pasta do zębów", "szampon", "płyn do naczyń", "papier toaletowy", "mydło",
+  { name: "pasta do zębów", unit: "szt" },
+  { name: "szampon", unit: "szt" },
+  { name: "płyn do naczyń", unit: "szt" },
+  { name: "papier toaletowy", unit: "op" },
+  { name: "mydło", unit: "szt" },
 ];
 
 async function main() {
@@ -41,8 +97,8 @@ async function main() {
 
   console.log(`Created list: ${list.name}`);
 
-  // Seed ItemHistory for autocomplete
-  for (const name of COMMON_ITEMS) {
+  // Seed ItemHistory for backward compat
+  for (const { name } of COMMON_ITEMS) {
     await prisma.itemHistory.upsert({
       where: { name: name.toLowerCase() },
       update: {},
@@ -54,7 +110,28 @@ async function main() {
     });
   }
 
-  console.log(`Seeded ${COMMON_ITEMS.length} history items`);
+  console.log(`Seeded ${COMMON_ITEMS.length} ItemHistory entries`);
+
+  // Seed global Products (userId=null, teamId=null)
+  for (const { name, unit } of COMMON_ITEMS) {
+    const existing = await prisma.product.findFirst({
+      where: { name: name.toLowerCase(), userId: null, teamId: null },
+    });
+    if (!existing) {
+      await prisma.product.create({
+        data: {
+          name: name.toLowerCase(),
+          category: categorize(name),
+          defaultUnit: unit ?? null,
+          useCount: 1,
+          userId: null,
+          teamId: null,
+        },
+      });
+    }
+  }
+
+  console.log(`Seeded ${COMMON_ITEMS.length} global Product entries`);
   console.log("Done.");
 }
 

--- a/worldofmag/src/actions/config.ts
+++ b/worldofmag/src/actions/config.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+
+async function requireAdmin() {
+  const session = await auth();
+  if (session?.user?.role !== "ADMIN") throw new Error("Forbidden");
+}
+
+export async function getConfigValue(key: string): Promise<string | null> {
+  const row = await prisma.config.findUnique({ where: { key } });
+  return row?.value ?? null;
+}
+
+export async function setConfigValue(key: string, value: string): Promise<void> {
+  await requireAdmin();
+  await prisma.config.upsert({
+    where: { key },
+    update: { value, updatedAt: new Date() },
+    create: { key, value, updatedAt: new Date() },
+  });
+}

--- a/worldofmag/src/actions/items.ts
+++ b/worldofmag/src/actions/items.ts
@@ -6,6 +6,7 @@ import { auth } from "@/lib/auth";
 import { categorize } from "@/lib/categorize";
 import { parseQuantity } from "@/lib/parseQuantity";
 import { assertListAccess } from "@/actions/lists";
+import { upsertUserProduct } from "@/actions/products";
 import type { Item, ItemStatus, ItemHistory } from "@/types";
 import type { Item as PrismaItem } from "@prisma/client";
 
@@ -40,6 +41,8 @@ export async function addItem(listId: string, rawText: string): Promise<Item> {
     },
     create: { name: name.toLowerCase(), category, unit: unit ?? null },
   });
+
+  await upsertUserProduct(name.toLowerCase(), unit ?? null, category);
 
   revalidatePath(`/shopping/${listId}`);
   return toItem(item);
@@ -95,6 +98,36 @@ export async function markAllInCart(listId: string): Promise<void> {
     data: { status: "IN_CART" },
   });
   revalidatePath(`/shopping/${listId}`);
+}
+
+export async function addItemStructured(
+  listId: string,
+  name: string,
+  quantity: number | null,
+  unit: string | null
+): Promise<Item> {
+  const user = await requireAuth();
+  await assertListAccess(listId, user.id);
+
+  const trimmedName = name.trim().toLowerCase();
+  const category = categorize(trimmedName);
+
+  const item = await prisma.item.create({
+    data: { listId, name: trimmedName, quantity, unit, category },
+  });
+
+  // Update legacy ItemHistory
+  await prisma.itemHistory.upsert({
+    where: { name: trimmedName },
+    update: { useCount: { increment: 1 }, category, unit: unit ?? undefined, updatedAt: new Date() },
+    create: { name: trimmedName, category, unit },
+  });
+
+  // Update product catalog
+  await upsertUserProduct(trimmedName, unit, category);
+
+  revalidatePath(`/shopping/${listId}`);
+  return toItem(item);
 }
 
 export async function getSuggestionsForPrefix(prefix: string): Promise<ItemHistory[]> {

--- a/worldofmag/src/actions/products.ts
+++ b/worldofmag/src/actions/products.ts
@@ -1,0 +1,165 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { categorize } from "@/lib/categorize";
+import type { Product } from "@/types";
+
+async function requireAuth() {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+  return session.user as { id: string };
+}
+
+async function getUserTeamIds(userId: string): Promise<string[]> {
+  const memberships = await prisma.teamMember.findMany({
+    where: { userId },
+    select: { teamId: true },
+  });
+  return memberships.map((m) => m.teamId);
+}
+
+export async function getProductSuggestions(prefix: string): Promise<Product[]> {
+  if (!prefix || prefix.length < 1) return [];
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+  const teamIds = userId ? await getUserTeamIds(userId) : [];
+
+  return prisma.product.findMany({
+    where: {
+      name: { contains: prefix.toLowerCase() },
+      OR: [
+        { userId: userId ?? undefined },
+        teamIds.length > 0 ? { teamId: { in: teamIds } } : {},
+        { userId: null, teamId: null },
+      ],
+    },
+    orderBy: [{ useCount: "desc" }, { name: "asc" }],
+    take: 10,
+  });
+}
+
+export async function getProducts(): Promise<Product[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  return prisma.product.findMany({
+    where: {
+      OR: [
+        { userId: user.id },
+        teamIds.length > 0 ? { teamId: { in: teamIds } } : {},
+        { userId: null, teamId: null },
+      ],
+    },
+    orderBy: [{ useCount: "desc" }, { name: "asc" }],
+  });
+}
+
+export async function upsertUserProduct(
+  name: string,
+  defaultUnit: string | null,
+  category?: string
+): Promise<Product> {
+  const user = await requireAuth();
+  const normalizedName = name.trim().toLowerCase();
+  const cat = category ?? categorize(name);
+
+  const existing = await prisma.product.findFirst({
+    where: { name: normalizedName, userId: user.id },
+  });
+
+  if (existing) {
+    return prisma.product.update({
+      where: { id: existing.id },
+      data: {
+        useCount: { increment: 1 },
+        defaultUnit: defaultUnit ?? existing.defaultUnit,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  return prisma.product.create({
+    data: {
+      name: normalizedName,
+      category: cat,
+      defaultUnit,
+      useCount: 1,
+      userId: user.id,
+      teamId: null,
+    },
+  });
+}
+
+export async function createProduct(data: {
+  name: string;
+  defaultUnit?: string | null;
+  category?: string;
+}): Promise<Product> {
+  const user = await requireAuth();
+  const normalizedName = data.name.trim().toLowerCase();
+  return prisma.product.create({
+    data: {
+      name: normalizedName,
+      category: data.category ?? categorize(data.name),
+      defaultUnit: data.defaultUnit ?? null,
+      useCount: 1,
+      userId: user.id,
+      teamId: null,
+    },
+  });
+}
+
+export async function updateProduct(
+  id: string,
+  data: { name?: string; defaultUnit?: string | null; category?: string }
+): Promise<Product> {
+  const user = await requireAuth();
+  const product = await prisma.product.findUnique({ where: { id } });
+  if (!product) throw new Error("Product not found");
+  if (product.userId !== user.id) throw new Error("Forbidden");
+
+  return prisma.product.update({
+    where: { id },
+    data: {
+      name: data.name ? data.name.trim().toLowerCase() : undefined,
+      defaultUnit: data.defaultUnit,
+      category: data.category,
+      updatedAt: new Date(),
+    },
+  });
+}
+
+export async function deleteProduct(id: string): Promise<void> {
+  const user = await requireAuth();
+  const product = await prisma.product.findUnique({ where: { id } });
+  if (!product) return;
+  if (product.userId !== user.id) throw new Error("Forbidden");
+  await prisma.product.delete({ where: { id } });
+  revalidatePath("/shopping/products");
+}
+
+export async function copyGlobalProduct(id: string): Promise<Product> {
+  const user = await requireAuth();
+  const global = await prisma.product.findUnique({ where: { id } });
+  if (!global || global.userId !== null || global.teamId !== null) {
+    throw new Error("Not a global product");
+  }
+
+  const existing = await prisma.product.findFirst({
+    where: { name: global.name, userId: user.id },
+  });
+  if (existing) return existing;
+
+  return prisma.product.create({
+    data: {
+      name: global.name,
+      category: global.category,
+      defaultUnit: global.defaultUnit,
+      useCount: 1,
+      userId: user.id,
+      teamId: null,
+    },
+  });
+}

--- a/worldofmag/src/app/admin/config/AdminConfigForm.tsx
+++ b/worldofmag/src/app/admin/config/AdminConfigForm.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, Eye, EyeOff } from "lucide-react";
+import { setConfigValue } from "@/actions/config";
+
+interface AdminConfigFormProps {
+  groqKey: string | null;
+}
+
+export function AdminConfigForm({ groqKey }: AdminConfigFormProps) {
+  const [key, setKey] = useState(groqKey ?? "");
+  const [showKey, setShowKey] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function save() {
+    startTransition(async () => {
+      await setConfigValue("groq_api_key", key.trim());
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    });
+  }
+
+  const maskedDisplay = groqKey
+    ? `${"•".repeat(Math.max(0, groqKey.length - 4))}${groqKey.slice(-4)}`
+    : "Nie ustawiony";
+
+  return (
+    <section>
+      <h2 style={{
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: "var(--text-muted)",
+        marginBottom: 12,
+      }}>
+        Konfiguracja LLM (Groq)
+      </h2>
+
+      <div style={{
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        overflow: "hidden",
+      }}>
+        <div style={{ padding: "16px" }}>
+          <p className="text-sm mb-1" style={{ color: "var(--text-secondary)" }}>
+            Klucz API Groq
+          </p>
+          <p className="text-xs mb-3" style={{ color: "var(--text-muted)" }}>
+            Uzyskaj bezpłatny klucz na{" "}
+            <span style={{ color: "var(--accent-blue)" }}>console.groq.com/keys</span>.
+            Używany do rozpoznawania listy zakupów z głosu i tekstu.
+          </p>
+
+          {groqKey && !showKey && (
+            <div
+              className="flex items-center gap-2 mb-3 px-3 py-2 rounded text-xs mono"
+              style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-muted)", border: "1px solid var(--border)" }}
+            >
+              <span className="flex-1">{maskedDisplay}</span>
+              <button
+                onClick={() => setShowKey(true)}
+                className="focus:outline-none"
+                style={{ color: "var(--text-muted)" }}
+              >
+                <Eye size={13} />
+              </button>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <div className="flex-1 flex items-center gap-1" style={{
+              backgroundColor: "var(--bg-base)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "6px 10px",
+            }}>
+              <input
+                type={showKey ? "text" : "password"}
+                value={key}
+                onChange={(e) => setKey(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") save(); }}
+                placeholder="gsk_..."
+                className="flex-1 bg-transparent mono text-sm focus:outline-none"
+                style={{ color: "var(--text-primary)" }}
+              />
+              <button
+                onClick={() => setShowKey((v) => !v)}
+                className="focus:outline-none flex-shrink-0"
+                style={{ color: "var(--text-muted)" }}
+              >
+                {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            </div>
+
+            <button
+              onClick={save}
+              disabled={isPending}
+              className="flex items-center gap-2 px-3 py-2 rounded text-sm font-medium focus:outline-none disabled:opacity-40"
+              style={{
+                backgroundColor: saved ? "var(--accent-green)" : "var(--accent-blue)",
+                color: "#fff",
+                transition: "background-color 0.2s",
+              }}
+            >
+              {saved ? <Check size={14} /> : null}
+              {saved ? "Zapisano" : "Zapisz"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/worldofmag/src/app/admin/config/page.tsx
+++ b/worldofmag/src/app/admin/config/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getConfigValue } from "@/actions/config";
+import { AdminConfigForm } from "./AdminConfigForm";
+
+export default async function AdminConfigPage() {
+  const session = await auth();
+  if (session?.user?.role !== "ADMIN") redirect("/");
+
+  const groqKey = await getConfigValue("groq_api_key");
+
+  return (
+    <div
+      className="flex-1 overflow-y-auto"
+      style={{ backgroundColor: "var(--bg-base)", padding: "32px 24px" }}
+    >
+      <div style={{ maxWidth: 640, margin: "0 auto" }}>
+        <div className="flex items-center gap-3 mb-6">
+          <span style={{ fontSize: 20 }}>⚙️</span>
+          <h1 style={{ fontSize: 18, fontWeight: 600, color: "var(--text-primary)", margin: 0 }}>
+            Konfiguracja systemu
+          </h1>
+        </div>
+
+        <AdminConfigForm groqKey={groqKey} />
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/app/admin/page.tsx
+++ b/worldofmag/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { auth } from "@/lib/auth"
-import { Shield, GitBranch, GitCommit, Clock, Hammer, MessageSquare } from "lucide-react"
+import { Shield, GitBranch, GitCommit, Clock, Hammer, MessageSquare, Settings } from "lucide-react"
+import Link from "next/link"
 
 function fmtDate(iso: string | undefined) {
   if (!iso || iso === "unknown") return "—"
@@ -104,6 +105,42 @@ export default async function AdminPage() {
                 </span>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Quick links */}
+        <section style={{ marginBottom: 24 }}>
+          <h2 style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-muted)",
+            marginBottom: 12,
+          }}>
+            Konfiguracja
+          </h2>
+          <div style={{
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 10,
+            overflow: "hidden",
+          }}>
+            <Link href="/admin/config" style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              padding: "12px 16px",
+              color: "var(--text-primary)",
+              textDecoration: "none",
+            }}
+              onMouseOver={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = "var(--bg-hover)"; }}
+              onMouseOut={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = ""; }}
+            >
+              <Settings size={15} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
+              <span style={{ fontSize: 13 }}>Konfiguracja LLM (klucz Groq)</span>
+              <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--text-muted)" }}>→</span>
+            </Link>
           </div>
         </section>
 

--- a/worldofmag/src/app/api/llm/normalize/route.ts
+++ b/worldofmag/src/app/api/llm/normalize/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const SYSTEM_PROMPT = `Jesteś asystentem listy zakupów. Użytkownik poda Ci tekst (mówiony lub pisany) opisujący produkty do kupienia.
+Przekształć go w tablicę JSON obiektów produktów.
+
+Zasady:
+- Każdy obiekt musi mieć pola: name (string, nazwa produktu po polsku, małymi literami), quantity (number lub null), unit (string lub null)
+- Jednostki: kg, dkg, g, l, ml, szt, op, paczka, butelka, puszka, torebka, słoik
+- Normalizuj nazwy produktów (np. "jabłuszka" → "jabłka", "dwa litry mleka" → name:"mleko", quantity:2, unit:"l")
+- Zwróć TYLKO tablicę JSON, bez żadnego innego tekstu.
+
+Przykład wejścia: "pół kilo jabłek, dwa litry mleka i chleb i 20 deko sera"
+Przykład wyjścia: [{"name":"jabłka","quantity":0.5,"unit":"kg"},{"name":"mleko","quantity":2,"unit":"l"},{"name":"chleb","quantity":null,"unit":null},{"name":"ser żółty","quantity":20,"unit":"dkg"}]`;
+
+export async function POST(req: NextRequest) {
+  const { text } = await req.json().catch(() => ({ text: "" }));
+  if (!text?.trim()) {
+    return NextResponse.json({ error: "Empty text" }, { status: 400 });
+  }
+
+  const config = await prisma.config.findUnique({ where: { key: "groq_api_key" } });
+  if (!config?.value) {
+    return NextResponse.json(
+      { error: "LLM nie jest skonfigurowany. Ustaw klucz Groq w Panelu Admina." },
+      { status: 503 }
+    );
+  }
+
+  const groqRes = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.value}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.1-8b-instant",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: text.trim() },
+      ],
+      temperature: 0.1,
+      max_tokens: 1024,
+    }),
+  });
+
+  if (!groqRes.ok) {
+    const err = await groqRes.text().catch(() => "unknown");
+    return NextResponse.json({ error: `Groq error: ${err}` }, { status: 502 });
+  }
+
+  const groqData = await groqRes.json();
+  const content: string = groqData.choices?.[0]?.message?.content ?? "[]";
+
+  let items: Array<{ name: string; quantity: number | null; unit: string | null }>;
+  try {
+    items = JSON.parse(content.trim());
+    if (!Array.isArray(items)) throw new Error("not array");
+  } catch {
+    return NextResponse.json({ error: "LLM zwrócił nieprawidłowy format" }, { status: 502 });
+  }
+
+  return NextResponse.json({ items });
+}

--- a/worldofmag/src/app/shopping/products/page.tsx
+++ b/worldofmag/src/app/shopping/products/page.tsx
@@ -1,0 +1,35 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { Package } from "lucide-react";
+import { getProducts } from "@/actions/products";
+import { ProductManager } from "@/components/shopping/ProductManager";
+
+export default async function ProductsPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const products = await getProducts();
+
+  return (
+    <div
+      className="flex-1 overflow-y-auto"
+      style={{ backgroundColor: "var(--bg-base)", padding: "24px 20px" }}
+    >
+      <div style={{ maxWidth: 720, margin: "0 auto" }}>
+        <div className="flex items-center gap-3 mb-6">
+          <Package size={20} style={{ color: "var(--accent-blue)" }} />
+          <h1 style={{ fontSize: 18, fontWeight: 600, color: "var(--text-primary)", margin: 0 }}>
+            Katalog produktów
+          </h1>
+        </div>
+        <p className="text-sm mb-6" style={{ color: "var(--text-muted)" }}>
+          Zarządzaj swoimi produktami. Domyślna jednostka jest podpowiadana przy dodawaniu do listy zakupów.
+        </p>
+
+        <ProductManager products={products} userId={session.user.id} />
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/shopping/ItemRow.tsx
+++ b/worldofmag/src/components/shopping/ItemRow.tsx
@@ -188,7 +188,16 @@ export function ItemRow({ item, isFocused, isEditing, onFocus, onStartEdit, onSt
         )}
       </button>
 
-      {/* Item name + details */}
+      {/* Qty + unit column */}
+      <div className="flex-shrink-0 text-right" style={{ width: 72 }}>
+        {(item.quantity != null || item.unit) ? (
+          <span className="mono text-xs" style={{ color: "var(--text-muted)" }}>
+            {item.quantity != null ? item.quantity : ""}{item.unit ? ` ${item.unit}` : ""}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Name column */}
       <div className="flex-1 min-w-0">
         <span
           className={cn("mono text-sm", isDone && "line-through")}
@@ -196,15 +205,10 @@ export function ItemRow({ item, isFocused, isEditing, onFocus, onStartEdit, onSt
         >
           {item.name}
         </span>
-        {(item.quantity || item.unit) && (
-          <span className="text-xs ml-2" style={{ color: "var(--text-muted)" }}>
-            {item.quantity}{item.unit ? ` ${item.unit}` : ""}
-          </span>
-        )}
         {item.notes && (
-          <span className="text-xs ml-2" style={{ color: "var(--text-muted)" }}>
-            — {item.notes}
-          </span>
+          <div className="text-xs mt-0.5" style={{ color: "var(--text-muted)" }}>
+            {item.notes}
+          </div>
         )}
       </div>
 

--- a/worldofmag/src/components/shopping/ListPicker.tsx
+++ b/worldofmag/src/components/shopping/ListPicker.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2, ShoppingCart, Pencil, Check, X } from "lucide-react";
+import { Plus, Trash2, ShoppingCart, Pencil, Check, X, Package } from "lucide-react";
 import type { ShoppingList } from "@/types";
 import { createList, deleteList, renameList } from "@/actions/lists";
 import { cn } from "@/lib/cn";
@@ -152,6 +152,26 @@ export function ListPicker({ allLists, currentListId }: ListPickerProps) {
             </div>
           );
         })}
+      </div>
+
+      {/* Catalog link */}
+      <div className="border-t py-1" style={{ borderColor: "var(--border)" }}>
+        <Link
+          href="/shopping/products"
+          className="flex items-center gap-2 px-3 py-1.5 rounded mx-1 text-xs focus:outline-none"
+          style={{ color: "var(--text-muted)" }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLElement).style.backgroundColor = "var(--bg-hover)";
+            (e.currentTarget as HTMLElement).style.color = "var(--text-secondary)";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLElement).style.backgroundColor = "";
+            (e.currentTarget as HTMLElement).style.color = "var(--text-muted)";
+          }}
+        >
+          <Package size={12} className="flex-shrink-0" />
+          <span>Katalog produktów</span>
+        </Link>
       </div>
     </div>
   );

--- a/worldofmag/src/components/shopping/ProductManager.tsx
+++ b/worldofmag/src/components/shopping/ProductManager.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Pencil, Trash2, Plus, Check, X, Copy } from "lucide-react";
+import type { Product } from "@/types";
+import { UNITS } from "@/types";
+import { createProduct, updateProduct, deleteProduct, copyGlobalProduct } from "@/actions/products";
+import { cn } from "@/lib/cn";
+
+const CATEGORIES = [
+  "Produce", "Dairy & Eggs", "Meat & Fish", "Bakery", "Dry Goods & Pasta",
+  "Drinks", "Frozen", "Snacks & Sweets", "Condiments & Oils", "Spices & Herbs",
+  "Cleaning & Hygiene", "Canned & Preserved", "Other",
+];
+
+interface ProductManagerProps {
+  products: Product[];
+  userId: string;
+}
+
+interface EditState {
+  id: string;
+  name: string;
+  defaultUnit: string;
+  category: string;
+}
+
+export function ProductManager({ products, userId }: ProductManagerProps) {
+  const [search, setSearch] = useState("");
+  const [editing, setEditing] = useState<EditState | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newUnit, setNewUnit] = useState("");
+  const [newCategory, setNewCategory] = useState("Other");
+  const [isPending, startTransition] = useTransition();
+
+  const personal = products.filter((p) => p.userId === userId);
+  const global = products.filter((p) => !p.userId && !p.teamId);
+
+  const filtered = (list: Product[]) =>
+    list.filter((p) => !search || p.name.toLowerCase().includes(search.toLowerCase()));
+
+  function startEdit(p: Product) {
+    setEditing({ id: p.id, name: p.name, defaultUnit: p.defaultUnit ?? "", category: p.category });
+  }
+
+  function saveEdit() {
+    if (!editing) return;
+    startTransition(async () => {
+      await updateProduct(editing.id, {
+        name: editing.name,
+        defaultUnit: editing.defaultUnit || null,
+        category: editing.category,
+      });
+    });
+    setEditing(null);
+  }
+
+  function handleDelete(id: string) {
+    startTransition(async () => { await deleteProduct(id); });
+  }
+
+  function handleCopy(id: string) {
+    startTransition(async () => { await copyGlobalProduct(id); });
+  }
+
+  function handleCreate() {
+    if (!newName.trim()) return;
+    startTransition(async () => {
+      await createProduct({ name: newName.trim(), defaultUnit: newUnit || null, category: newCategory });
+    });
+    setNewName("");
+    setNewUnit("");
+    setNewCategory("Other");
+    setAdding(false);
+  }
+
+  const inputStyle = {
+    backgroundColor: "var(--bg-base)",
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    color: "var(--text-primary)",
+    padding: "4px 8px",
+    fontSize: 13,
+    outline: "none",
+  };
+
+  return (
+    <div>
+      {/* Search + Add */}
+      <div className="flex items-center gap-3 mb-6">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Szukaj produktu…"
+          className="flex-1 mono text-sm focus:outline-none"
+          style={{ ...inputStyle, padding: "6px 12px" }}
+        />
+        <button
+          onClick={() => setAdding(true)}
+          className="flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium focus:outline-none"
+          style={{ backgroundColor: "var(--accent-blue)", color: "#fff" }}
+        >
+          <Plus size={14} />
+          Nowy produkt
+        </button>
+      </div>
+
+      {/* Add form */}
+      {adding && (
+        <div
+          className="flex flex-wrap items-center gap-2 p-3 rounded-lg mb-4 border"
+          style={{ backgroundColor: "var(--bg-elevated)", borderColor: "var(--accent-blue)" }}
+        >
+          <input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") handleCreate(); if (e.key === "Escape") setAdding(false); }}
+            placeholder="Nazwa produktu"
+            className="mono text-sm focus:outline-none flex-1"
+            style={inputStyle}
+            autoFocus
+          />
+          <UnitDropdown value={newUnit} onChange={setNewUnit} />
+          <select
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            className="text-sm focus:outline-none"
+            style={{ ...inputStyle, width: 160 }}
+          >
+            {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <button onClick={handleCreate} disabled={!newName.trim()} className="p-1.5 rounded focus:outline-none disabled:opacity-40" style={{ color: "var(--accent-blue)" }}>
+            <Check size={16} />
+          </button>
+          <button onClick={() => setAdding(false)} className="p-1.5 rounded focus:outline-none" style={{ color: "var(--text-muted)" }}>
+            <X size={16} />
+          </button>
+        </div>
+      )}
+
+      {/* Personal products */}
+      <Section
+        title="Moje produkty"
+        products={filtered(personal)}
+        editing={editing}
+        onEdit={startEdit}
+        onSave={saveEdit}
+        onCancel={() => setEditing(null)}
+        onDelete={handleDelete}
+        onChange={(patch) => setEditing((e) => e ? { ...e, ...patch } : e)}
+        editable
+      />
+
+      {/* Global products */}
+      <Section
+        title="Katalog globalny"
+        subtitle="Produkty dostępne dla wszystkich. Kliknij kopiuj by dodać do swoich."
+        products={filtered(global)}
+        editing={null}
+        onEdit={() => {}}
+        onSave={() => {}}
+        onCancel={() => {}}
+        onDelete={() => {}}
+        onChange={() => {}}
+        editable={false}
+        onCopy={handleCopy}
+        alreadyCopied={(id) => personal.some((p) => {
+          const g = global.find((g) => g.id === id);
+          return g ? p.name === g.name : false;
+        })}
+      />
+    </div>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  subtitle?: string;
+  products: Product[];
+  editing: EditState | null;
+  editable: boolean;
+  onEdit: (p: Product) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onDelete: (id: string) => void;
+  onChange: (patch: Partial<EditState>) => void;
+  onCopy?: (id: string) => void;
+  alreadyCopied?: (id: string) => boolean;
+}
+
+function Section({ title, subtitle, products, editing, editable, onEdit, onSave, onCancel, onDelete, onChange, onCopy, alreadyCopied }: SectionProps) {
+  return (
+    <div className="mb-8">
+      <h2 style={{ fontSize: 11, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--text-muted)", marginBottom: 8 }}>
+        {title}
+      </h2>
+      {subtitle && (
+        <p className="text-xs mb-3" style={{ color: "var(--text-muted)" }}>{subtitle}</p>
+      )}
+
+      {products.length === 0 ? (
+        <p className="text-sm" style={{ color: "var(--text-muted)" }}>Brak produktów.</p>
+      ) : (
+        <div style={{ backgroundColor: "var(--bg-surface)", border: "1px solid var(--border)", borderRadius: 10, overflow: "hidden" }}>
+          {products.map((p, i) => {
+            const isEditing = editing?.id === p.id;
+            return (
+              <div
+                key={p.id}
+                className="flex items-center gap-3 px-4 py-2"
+                style={{
+                  borderBottom: i < products.length - 1 ? "1px solid var(--border)" : undefined,
+                  backgroundColor: isEditing ? "var(--bg-elevated)" : undefined,
+                }}
+              >
+                {isEditing && editing ? (
+                  <>
+                    <input
+                      value={editing.name}
+                      onChange={(e) => onChange({ name: e.target.value })}
+                      onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
+                      className="flex-1 mono text-sm focus:outline-none"
+                      style={{ backgroundColor: "var(--bg-base)", border: "1px solid var(--border)", borderRadius: 4, padding: "2px 6px", color: "var(--text-primary)" }}
+                      autoFocus
+                    />
+                    <UnitDropdown value={editing.defaultUnit} onChange={(v) => onChange({ defaultUnit: v })} />
+                    <select
+                      value={editing.category}
+                      onChange={(e) => onChange({ category: e.target.value })}
+                      className="text-xs focus:outline-none"
+                      style={{ backgroundColor: "var(--bg-base)", border: "1px solid var(--border)", borderRadius: 4, padding: "2px 6px", color: "var(--text-secondary)", width: 140 }}
+                    >
+                      {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                    <button onClick={onSave} className="p-1 focus:outline-none" style={{ color: "var(--accent-blue)" }}><Check size={14} /></button>
+                    <button onClick={onCancel} className="p-1 focus:outline-none" style={{ color: "var(--text-muted)" }}><X size={14} /></button>
+                  </>
+                ) : (
+                  <>
+                    <span className="mono text-sm flex-1 truncate" style={{ color: "var(--text-primary)" }}>{p.name}</span>
+                    <span className="text-xs" style={{ color: "var(--text-muted)", minWidth: 36 }}>{p.defaultUnit ?? "—"}</span>
+                    <span className="text-xs" style={{ color: "var(--text-muted)", minWidth: 100 }}>{p.category}</span>
+                    {editable ? (
+                      <div className="flex items-center gap-1 ml-2">
+                        <button onClick={() => onEdit(p)} className="p-1 focus:outline-none" style={{ color: "var(--text-muted)" }}
+                          onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text-secondary)"; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; }}>
+                          <Pencil size={13} />
+                        </button>
+                        <button onClick={() => onDelete(p.id)} className="p-1 focus:outline-none" style={{ color: "var(--text-muted)" }}
+                          onMouseEnter={(e) => { e.currentTarget.style.color = "var(--accent-red)"; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; }}>
+                          <Trash2 size={13} />
+                        </button>
+                      </div>
+                    ) : onCopy ? (
+                      <button
+                        onClick={() => onCopy(p.id)}
+                        disabled={alreadyCopied?.(p.id)}
+                        className="ml-2 p-1 focus:outline-none disabled:opacity-30"
+                        style={{ color: "var(--text-muted)" }}
+                        title={alreadyCopied?.(p.id) ? "Już w Twoim katalogu" : "Kopiuj do moich"}
+                        onMouseEnter={(e) => { if (!alreadyCopied?.(p.id)) e.currentTarget.style.color = "var(--accent-blue)"; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; }}
+                      >
+                        <Copy size={13} />
+                      </button>
+                    ) : null}
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UnitDropdown({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="text-xs focus:outline-none"
+      style={{
+        backgroundColor: "var(--bg-base)",
+        border: "1px solid var(--border)",
+        borderRadius: 4,
+        padding: "2px 6px",
+        color: value ? "var(--text-secondary)" : "var(--text-muted)",
+        width: 80,
+      }}
+    >
+      <option value="">Brak</option>
+      {UNITS.map((u) => <option key={u.value} value={u.value}>{u.label}</option>)}
+    </select>
+  );
+}

--- a/worldofmag/src/components/shopping/QuickAddBar.tsx
+++ b/worldofmag/src/components/shopping/QuickAddBar.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useRef, useState, useEffect, useTransition, forwardRef, useImperativeHandle } from "react";
-import { Plus, Loader2 } from "lucide-react";
-import type { ItemHistory } from "@/types";
-import { addItem, getSuggestionsForPrefix } from "@/actions/items";
+import { Plus, Loader2, Mic } from "lucide-react";
+import type { Product } from "@/types";
+import { UNITS } from "@/types";
+import { addItemStructured } from "@/actions/items";
+import { getProductSuggestions } from "@/actions/products";
+import { VoiceLLMModal } from "./VoiceLLMModal";
 
 interface QuickAddBarProps {
   listId: string;
@@ -15,134 +18,259 @@ export interface QuickAddBarHandle {
 
 export const QuickAddBar = forwardRef<QuickAddBarHandle, QuickAddBarProps>(
   function QuickAddBar({ listId }, ref) {
-    const [value, setValue] = useState("");
-    const [suggestions, setSuggestions] = useState<ItemHistory[]>([]);
+    const [name, setName] = useState("");
+    const [qty, setQty] = useState("");
+    const [unit, setUnit] = useState("");
+    const [suggestions, setSuggestions] = useState<Product[]>([]);
     const [suggestionIndex, setSuggestionIndex] = useState(-1);
     const [isPending, startTransition] = useTransition();
-    const inputRef = useRef<HTMLInputElement>(null);
+    const [showVoice, setShowVoice] = useState(false);
+    const nameRef = useRef<HTMLInputElement>(null);
+    const qtyRef = useRef<HTMLInputElement>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
     useImperativeHandle(ref, () => ({
-      focus: () => inputRef.current?.focus(),
+      focus: () => nameRef.current?.focus(),
     }));
 
     useEffect(() => {
       clearTimeout(debounceRef.current);
-      if (!value.trim()) { setSuggestions([]); return; }
+      if (!name.trim()) { setSuggestions([]); return; }
       debounceRef.current = setTimeout(async () => {
-        const results = await getSuggestionsForPrefix(value.trim());
+        const results = await getProductSuggestions(name.trim());
         setSuggestions(results);
         setSuggestionIndex(-1);
       }, 150);
       return () => clearTimeout(debounceRef.current);
-    }, [value]);
+    }, [name]);
 
-    function submit(rawText: string) {
-      if (!rawText.trim()) return;
-      setValue("");
+    function selectSuggestion(product: Product) {
+      setName(product.name);
+      if (product.defaultUnit) setUnit(product.defaultUnit);
       setSuggestions([]);
       setSuggestionIndex(-1);
-      startTransition(() => { addItem(listId, rawText.trim()); });
+      qtyRef.current?.focus();
     }
 
-    function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    function submit() {
+      if (!name.trim()) return;
+      const parsedQty = qty.trim() ? parseFloat(qty.trim()) : null;
+      const parsedUnit = unit.trim() || null;
+      startTransition(() => {
+        addItemStructured(listId, name.trim(), parsedQty, parsedUnit);
+      });
+      setName("");
+      setQty("");
+      setUnit("");
+      setSuggestions([]);
+      setSuggestionIndex(-1);
+      setTimeout(() => nameRef.current?.focus(), 50);
+    }
+
+    function handleNameKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSuggestionIndex((i) => Math.min(i + 1, suggestions.length - 1));
+        if (suggestions.length > 0) setSuggestionIndex((i) => Math.min(i + 1, suggestions.length - 1));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setSuggestionIndex((i) => Math.max(i - 1, -1));
       } else if (e.key === "Enter") {
         e.preventDefault();
         if (suggestionIndex >= 0 && suggestions[suggestionIndex]) {
-          submit(suggestions[suggestionIndex].name);
+          selectSuggestion(suggestions[suggestionIndex]);
         } else {
-          submit(value);
-        }
-      } else if (e.key === "Escape") {
-        if (suggestions.length > 0) {
           setSuggestions([]);
-        } else {
-          setValue("");
-          inputRef.current?.blur();
+          qtyRef.current?.focus();
         }
       } else if (e.key === "Tab" && suggestions.length > 0) {
         e.preventDefault();
         const idx = suggestionIndex >= 0 ? suggestionIndex : 0;
-        setValue(suggestions[idx]?.name ?? value);
-        setSuggestions([]);
+        if (suggestions[idx]) selectSuggestion(suggestions[idx]);
+      } else if (e.key === "Escape") {
+        if (suggestions.length > 0) {
+          setSuggestions([]);
+        } else {
+          setName(""); setQty(""); setUnit("");
+          nameRef.current?.blur();
+        }
       }
     }
 
+    function handleQtyKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+      if (e.key === "Enter") { e.preventDefault(); submit(); }
+      if (e.key === "Escape") { nameRef.current?.focus(); }
+    }
+
+    function handleUnitKeyDown(e: React.KeyboardEvent<HTMLSelectElement | HTMLInputElement>) {
+      if (e.key === "Enter") { e.preventDefault(); submit(); }
+      if (e.key === "Escape") { nameRef.current?.focus(); }
+    }
+
     return (
-      <div
-        className="relative border-b"
-        style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
-      >
-        <div className="flex items-center gap-3 px-4 py-3">
-          {isPending ? (
-            <Loader2 size={16} className="animate-spin flex-shrink-0" style={{ color: "var(--accent-blue)" }} />
-          ) : (
-            <Plus size={16} className="flex-shrink-0" style={{ color: "var(--text-muted)" }} />
-          )}
-          <input
-            ref={inputRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Add item… e.g. '2 butelki mleka' or 'jajka x12'"
-            className="flex-1 bg-transparent mono text-sm focus:outline-none"
-            style={{
-              color: "var(--text-primary)",
-              caretColor: "var(--accent-blue)",
-            }}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          {value && (
-            <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-              <kbd>Enter</kbd> to add
-            </span>
+      <>
+        <div
+          className="relative border-b"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+        >
+          <div className="flex flex-col md:flex-row md:items-center gap-0">
+            {/* Name input */}
+            <div className="flex items-center gap-2 px-4 py-2 flex-1">
+              {isPending ? (
+                <Loader2 size={15} className="animate-spin flex-shrink-0" style={{ color: "var(--accent-blue)" }} />
+              ) : (
+                <Plus size={15} className="flex-shrink-0" style={{ color: "var(--text-muted)" }} />
+              )}
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={handleNameKeyDown}
+                placeholder="Nazwa produktu…"
+                className="flex-1 bg-transparent mono text-sm focus:outline-none"
+                style={{ color: "var(--text-primary)", caretColor: "var(--accent-blue)" }}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+
+            {/* Qty + unit + buttons */}
+            <div
+              className="flex items-center gap-2 px-4 pb-2 md:py-2 md:px-3 md:border-l"
+              style={{ borderColor: "var(--border)" }}
+            >
+              <input
+                ref={qtyRef}
+                value={qty}
+                onChange={(e) => setQty(e.target.value)}
+                onKeyDown={handleQtyKeyDown}
+                placeholder="Ilość"
+                type="number"
+                min="0"
+                step="any"
+                className="bg-transparent mono text-sm text-right focus:outline-none"
+                style={{ width: 52, color: "var(--text-secondary)", caretColor: "var(--accent-blue)" }}
+              />
+
+              <UnitSelect value={unit} onChange={setUnit} onKeyDown={handleUnitKeyDown} />
+
+              <button
+                onClick={submit}
+                disabled={!name.trim() || isPending}
+                className="flex items-center justify-center rounded px-2 py-1 text-xs font-medium focus:outline-none disabled:opacity-40"
+                style={{ backgroundColor: "var(--accent-blue)", color: "#fff" }}
+                title="Dodaj (Enter)"
+              >
+                <Plus size={14} />
+              </button>
+
+              <button
+                onClick={() => setShowVoice(true)}
+                className="flex items-center justify-center rounded p-1.5 focus:outline-none"
+                style={{ color: "var(--text-muted)", backgroundColor: "var(--bg-elevated)" }}
+                title="Dodaj głosem / przez LLM"
+                type="button"
+              >
+                <Mic size={15} />
+              </button>
+            </div>
+          </div>
+
+          {/* Autocomplete dropdown */}
+          {suggestions.length > 0 && (
+            <div
+              className="absolute left-0 right-0 z-50 shadow-lg"
+              style={{
+                top: "100%",
+                backgroundColor: "var(--bg-elevated)",
+                border: `1px solid var(--border)`,
+                borderTop: "none",
+              }}
+            >
+              {suggestions.map((s, i) => (
+                <button
+                  key={s.id}
+                  onClick={() => selectSuggestion(s)}
+                  className="flex items-center gap-3 w-full px-4 py-2 text-left focus:outline-none"
+                  style={{
+                    backgroundColor: i === suggestionIndex ? "var(--bg-hover)" : undefined,
+                    color: "var(--text-primary)",
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = "var(--bg-hover)"; }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = i === suggestionIndex ? "var(--bg-hover)" : "";
+                  }}
+                >
+                  <span className="mono text-sm">{s.name}</span>
+                  <span className="text-xs ml-auto" style={{ color: "var(--text-muted)" }}>
+                    {s.category}
+                    {s.defaultUnit ? ` · ${s.defaultUnit}` : ""}
+                    {!s.userId && !s.teamId && (
+                      <span className="ml-1 opacity-40">global</span>
+                    )}
+                  </span>
+                </button>
+              ))}
+            </div>
           )}
         </div>
 
-        {/* Autocomplete dropdown */}
-        {suggestions.length > 0 && (
-          <div
-            className="absolute left-0 right-0 z-50 border-t shadow-lg"
-            style={{
-              top: "100%",
-              backgroundColor: "var(--bg-elevated)",
-              borderColor: "var(--border)",
-              borderBottom: `1px solid var(--border)`,
-              borderLeft: `1px solid var(--border)`,
-              borderRight: `1px solid var(--border)`,
-            }}
-          >
-            {suggestions.map((s, i) => (
-              <button
-                key={s.id}
-                onClick={() => submit(s.name)}
-                className="flex items-center gap-3 w-full px-4 py-2 text-left focus:outline-none"
-                style={{
-                  backgroundColor: i === suggestionIndex ? "var(--bg-hover)" : undefined,
-                  color: "var(--text-primary)",
-                }}
-                onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = "var(--bg-hover)"; }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = i === suggestionIndex ? "var(--bg-hover)" : "";
-                }}
-              >
-                <span className="mono text-sm">{s.name}</span>
-                <span className="text-xs ml-auto" style={{ color: "var(--text-muted)" }}>
-                  {s.category}
-                  {s.unit && ` · ${s.unit}`}
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+        <VoiceLLMModal open={showVoice} onClose={() => setShowVoice(false)} listId={listId} />
+      </>
     );
   }
 );
+
+interface UnitSelectProps {
+  value: string;
+  onChange: (v: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLSelectElement | HTMLInputElement>) => void;
+}
+
+function UnitSelect({ value, onChange, onKeyDown }: UnitSelectProps) {
+  const isCustom = value !== "" && !UNITS.find((u) => u.value === value);
+
+  if (isCustom) {
+    return (
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="jednostka"
+        className="bg-transparent mono text-sm focus:outline-none"
+        style={{ width: 72, color: "var(--text-secondary)", caretColor: "var(--accent-blue)" }}
+        autoFocus
+      />
+    );
+  }
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => {
+        if (e.target.value === "__custom__") {
+          onChange("_");
+        } else {
+          onChange(e.target.value);
+        }
+      }}
+      onKeyDown={onKeyDown}
+      className="bg-transparent mono text-sm focus:outline-none cursor-pointer"
+      style={{
+        color: value ? "var(--text-secondary)" : "var(--text-muted)",
+        width: 72,
+        border: "none",
+        outline: "none",
+        appearance: "none",
+        WebkitAppearance: "none",
+      }}
+    >
+      <option value="">Jedn.</option>
+      {UNITS.map((u) => (
+        <option key={u.value} value={u.value} style={{ backgroundColor: "var(--bg-elevated)" }}>
+          {u.label}
+        </option>
+      ))}
+      <option value="__custom__" style={{ backgroundColor: "var(--bg-elevated)" }}>Inna…</option>
+    </select>
+  );
+}

--- a/worldofmag/src/components/shopping/VoiceLLMModal.tsx
+++ b/worldofmag/src/components/shopping/VoiceLLMModal.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useState, useRef, useEffect, useTransition } from "react";
+import { Mic, MicOff, Loader2, X, Plus, CheckSquare, Square } from "lucide-react";
+import { UNITS } from "@/types";
+import { addItemStructured } from "@/actions/items";
+import { upsertUserProduct, getProductSuggestions } from "@/actions/products";
+import { cn } from "@/lib/cn";
+
+interface ParsedRow {
+  name: string;
+  quantity: number | null;
+  unit: string;
+  selected: boolean;
+  addToCatalog: boolean;
+  isNew: boolean;
+}
+
+interface VoiceLLMModalProps {
+  open: boolean;
+  onClose: () => void;
+  listId: string;
+}
+
+// Web Speech API types (not in TS lib.dom.d.ts for all browsers)
+interface ISpeechResult {
+  resultIndex: number;
+  results: { isFinal: boolean; 0: { transcript: string } }[];
+}
+interface ISpeechError { error: string }
+interface ISpeechRecognition extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((e: ISpeechResult) => void) | null;
+  onerror: ((e: ISpeechError) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+}
+interface ISpeechRecognitionCtor { new(): ISpeechRecognition }
+declare global {
+  interface Window {
+    SpeechRecognition?: ISpeechRecognitionCtor;
+    webkitSpeechRecognition?: ISpeechRecognitionCtor;
+  }
+}
+
+export function VoiceLLMModal({ open, onClose, listId }: VoiceLLMModalProps) {
+  const [text, setText] = useState("");
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [recording, setRecording] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const recognitionRef = useRef<ISpeechRecognition | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setText("");
+      setRows([]);
+      setError(null);
+      setTranscript("");
+      setTimeout(() => textareaRef.current?.focus(), 100);
+    } else {
+      stopRecording();
+    }
+  }, [open]);
+
+  function stopRecording() {
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+      recognitionRef.current = null;
+    }
+    setRecording(false);
+  }
+
+  function startRecording() {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) {
+      setError("Twoja przeglądarka nie obsługuje rozpoznawania mowy. Wpisz tekst ręcznie.");
+      return;
+    }
+    const rec = new SR();
+    rec.lang = "pl-PL";
+    rec.continuous = true;
+    rec.interimResults = true;
+
+    rec.onresult = (e: ISpeechResult) => {
+      let interim = "";
+      let final = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        if (e.results[i].isFinal) {
+          final += e.results[i][0].transcript + " ";
+        } else {
+          interim += e.results[i][0].transcript;
+        }
+      }
+      setTranscript((prev) => prev + final);
+      setText((prev) => prev + final + interim);
+    };
+
+    rec.onerror = (e: ISpeechError) => {
+      setError(`Błąd mikrofonu: ${e.error}`);
+      stopRecording();
+    };
+
+    rec.onend = () => {
+      setRecording(false);
+    };
+
+    recognitionRef.current = rec;
+    rec.start();
+    setRecording(true);
+    setError(null);
+  }
+
+  function toggleRecording() {
+    if (recording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  }
+
+  async function processText() {
+    const input = text.trim();
+    if (!input) return;
+    stopRecording();
+    setLoading(true);
+    setError(null);
+    setRows([]);
+
+    try {
+      const res = await fetch("/api/llm/normalize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: input }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Błąd przetwarzania");
+        return;
+      }
+
+      const parsed: Array<{ name: string; quantity: number | null; unit: string | null }> = data.items;
+
+      const withNew: ParsedRow[] = await Promise.all(
+        parsed.map(async (p) => {
+          const suggestions = await getProductSuggestions(p.name);
+          const isNew = suggestions.length === 0 || !suggestions.some(
+            (s) => s.name.toLowerCase() === p.name.toLowerCase()
+          );
+          return {
+            name: p.name,
+            quantity: p.quantity,
+            unit: p.unit ?? "",
+            selected: true,
+            addToCatalog: isNew,
+            isNew,
+          };
+        })
+      );
+
+      setRows(withNew);
+    } catch {
+      setError("Nie udało się połączyć z LLM");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function updateRow(i: number, patch: Partial<ParsedRow>) {
+    setRows((prev) => prev.map((r, idx) => idx === i ? { ...r, ...patch } : r));
+  }
+
+  function addToList() {
+    const toAdd = rows.filter((r) => r.selected);
+    if (toAdd.length === 0) return;
+
+    startTransition(async () => {
+      for (const row of toAdd) {
+        await addItemStructured(listId, row.name, row.quantity, row.unit || null);
+        if (row.addToCatalog) {
+          await upsertUserProduct(row.name, row.unit || null);
+        }
+      }
+    });
+
+    onClose();
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.7)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="w-full md:max-w-lg rounded-t-xl md:rounded-xl overflow-hidden"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "1px solid var(--border)",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-4 py-3 border-b flex-shrink-0"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <div className="flex items-center gap-2">
+            <Mic size={16} style={{ color: "var(--accent-blue)" }} />
+            <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              Dodaj głosem / przez LLM
+            </span>
+          </div>
+          <button onClick={onClose} className="p-1 rounded focus:outline-none" style={{ color: "var(--text-muted)" }}>
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Input area */}
+        {rows.length === 0 && (
+          <div className="p-4 flex-shrink-0">
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Wpisz lub powiedz co chcesz kupić…&#10;Np. 'pół kilo jabłek, 2 litry mleka i chleb'"
+              className="w-full bg-transparent mono text-sm focus:outline-none resize-none"
+              style={{
+                color: "var(--text-primary)",
+                caretColor: "var(--accent-blue)",
+                minHeight: 80,
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) processText();
+              }}
+            />
+            {recording && (
+              <div className="flex items-center gap-2 mt-1">
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ backgroundColor: "var(--accent-red)", animation: "pulse 1s infinite" }}
+                />
+                <span className="text-xs" style={{ color: "var(--accent-red)" }}>Nasłuchuję…</span>
+              </div>
+            )}
+            {error && (
+              <p className="text-xs mt-2" style={{ color: "var(--accent-red)" }}>{error}</p>
+            )}
+
+            <div className="flex items-center gap-2 mt-3">
+              <button
+                onClick={toggleRecording}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-1.5 rounded text-xs font-medium focus:outline-none",
+                  recording && "animate-pulse"
+                )}
+                style={{
+                  backgroundColor: recording ? "rgba(239,68,68,0.2)" : "var(--bg-elevated)",
+                  color: recording ? "var(--accent-red)" : "var(--text-secondary)",
+                  border: `1px solid ${recording ? "var(--accent-red)" : "var(--border)"}`,
+                }}
+              >
+                {recording ? <MicOff size={14} /> : <Mic size={14} />}
+                {recording ? "Zatrzymaj" : "Nagraj"}
+              </button>
+
+              <button
+                onClick={processText}
+                disabled={!text.trim() || loading}
+                className="flex items-center gap-2 px-3 py-1.5 rounded text-xs font-medium focus:outline-none disabled:opacity-40 ml-auto"
+                style={{ backgroundColor: "var(--accent-blue)", color: "#fff" }}
+              >
+                {loading && <Loader2 size={13} className="animate-spin" />}
+                Przetwórz
+              </button>
+            </div>
+            <p className="text-xs mt-2" style={{ color: "var(--text-muted)" }}>
+              Ctrl+Enter aby przetworzyć
+            </p>
+          </div>
+        )}
+
+        {/* Results preview */}
+        {rows.length > 0 && (
+          <div className="flex-1 overflow-y-auto">
+            <div className="px-4 pt-3 pb-1">
+              <p className="text-xs font-medium" style={{ color: "var(--text-muted)" }}>
+                Rozpoznane produkty — zaznacz które dodać do listy
+              </p>
+            </div>
+
+            {rows.map((row, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-2 px-4 py-2 border-b"
+                style={{ borderColor: "var(--border)" }}
+              >
+                {/* Selected checkbox */}
+                <button
+                  onClick={() => updateRow(i, { selected: !row.selected })}
+                  className="flex-shrink-0 focus:outline-none"
+                  style={{ color: row.selected ? "var(--accent-blue)" : "var(--text-muted)" }}
+                >
+                  {row.selected ? <CheckSquare size={16} /> : <Square size={16} />}
+                </button>
+
+                {/* Product name */}
+                <span
+                  className="mono text-sm flex-1 min-w-0 truncate"
+                  style={{ color: row.selected ? "var(--text-primary)" : "var(--text-muted)" }}
+                >
+                  {row.isNew && (
+                    <span className="mr-1 text-xs" style={{ color: "var(--accent-blue)" }}>+</span>
+                  )}
+                  {row.name}
+                </span>
+
+                {/* Qty */}
+                <input
+                  type="number"
+                  value={row.quantity ?? ""}
+                  onChange={(e) => updateRow(i, { quantity: e.target.value ? parseFloat(e.target.value) : null })}
+                  className="bg-transparent mono text-xs text-right focus:outline-none"
+                  style={{ width: 48, color: "var(--text-secondary)", border: `1px solid var(--border)`, borderRadius: 4, padding: "1px 4px" }}
+                  placeholder="qty"
+                />
+
+                {/* Unit */}
+                <select
+                  value={UNITS.find((u) => u.value === row.unit) ? row.unit : (row.unit ? "__other__" : "")}
+                  onChange={(e) => updateRow(i, { unit: e.target.value === "__other__" ? row.unit : e.target.value })}
+                  className="bg-transparent mono text-xs focus:outline-none"
+                  style={{
+                    color: "var(--text-secondary)",
+                    width: 64,
+                    border: `1px solid var(--border)`,
+                    borderRadius: 4,
+                    padding: "1px 4px",
+                    backgroundColor: "var(--bg-elevated)",
+                  }}
+                >
+                  <option value="">—</option>
+                  {UNITS.map((u) => (
+                    <option key={u.value} value={u.value}>{u.value}</option>
+                  ))}
+                </select>
+
+                {/* Add to catalog toggle (new products only) */}
+                {row.isNew && (
+                  <button
+                    onClick={() => updateRow(i, { addToCatalog: !row.addToCatalog })}
+                    className="flex-shrink-0 text-xs px-1.5 py-0.5 rounded focus:outline-none"
+                    style={{
+                      backgroundColor: row.addToCatalog ? "rgba(59,130,246,0.15)" : "var(--bg-elevated)",
+                      color: row.addToCatalog ? "var(--accent-blue)" : "var(--text-muted)",
+                      border: `1px solid ${row.addToCatalog ? "var(--accent-blue)" : "var(--border)"}`,
+                      fontSize: 10,
+                    }}
+                    title="Dodaj do katalogu produktów"
+                  >
+                    📚
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Footer */}
+        {rows.length > 0 && (
+          <div
+            className="flex items-center justify-between gap-3 px-4 py-3 border-t flex-shrink-0"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <button
+              onClick={() => { setRows([]); setText(""); }}
+              className="text-xs focus:outline-none"
+              style={{ color: "var(--text-muted)" }}
+            >
+              ← Wróć
+            </button>
+            <div className="flex items-center gap-2">
+              <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+                {rows.filter((r) => r.selected).length} z {rows.length} zaznaczonych
+              </span>
+              <button
+                onClick={addToList}
+                disabled={rows.filter((r) => r.selected).length === 0 || isPending}
+                className="flex items-center gap-2 px-3 py-1.5 rounded text-xs font-medium focus:outline-none disabled:opacity-40"
+                style={{ backgroundColor: "var(--accent-blue)", color: "#fff" }}
+              >
+                {isPending ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+                Dodaj do listy
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/types/index.ts
+++ b/worldofmag/src/types/index.ts
@@ -1,6 +1,23 @@
-import type { Item as PrismaItem, ShoppingList as PrismaShoppingList, ItemHistory } from "@prisma/client";
+import type { Item as PrismaItem, ShoppingList as PrismaShoppingList, ItemHistory, Product as PrismaProduct } from "@prisma/client";
 
 export type { ItemHistory };
+
+export type Product = PrismaProduct;
+
+export const UNITS: Array<{ value: string; label: string }> = [
+  { value: "szt",     label: "szt" },
+  { value: "kg",      label: "kg" },
+  { value: "dkg",     label: "dkg" },
+  { value: "g",       label: "g" },
+  { value: "l",       label: "l" },
+  { value: "ml",      label: "ml" },
+  { value: "op",      label: "op" },
+  { value: "paczka",  label: "paczka" },
+  { value: "butelka", label: "butelka" },
+  { value: "puszka",  label: "puszka" },
+  { value: "torebka", label: "torebka" },
+  { value: "słoik",   label: "słoik" },
+];
 
 export type ShoppingList = PrismaShoppingList & {
   ownerTeam?: { id: string; name: string } | null;


### PR DESCRIPTION
- Add Product and Config models to schema (migration 0003)
- Per-user/team product catalog with global seed products (69 items with default units)
- QuickAddBar redesigned: structured fields (name autocomplete + qty + unit dropdown)
- ItemRow: two-column layout — qty+unit column | name column
- VoiceLLMModal: microphone recording (Web Speech API) + text input → Groq LLM normalization → preview with checkboxes
- /shopping/products: product catalog management page (edit/delete personal, copy global)
- /admin/config: Groq API key configuration (admin panel)
- addItemStructured action: creates item + upserts user product catalog
- Unit selector with predefined Polish shopping units (szt, kg, dkg, g, l, ml, op, ...)
- ListPicker: "Katalog produktów" link at bottom of sidebar

https://claude.ai/code/session_01As9mhUu3nL6L8xSgaNJ2Jp