### PR TITLE
Adjust muted text color for improved contrast

### DIFF
--- a/worldofmag/src/app/globals.css
+++ b/worldofmag/src/app/globals.css
@@ -11,7 +11,7 @@
   --border-focus:   #444444;
   --text-primary:   #e8e8e8;
   --text-secondary: #888888;
-  --text-muted:     #555555;
+  --text-muted:     #808080;
   --accent-blue:    #3b82f6;
   --accent-blue-dim: #1d4ed8;
   --accent-green:   #22c55e;


### PR DESCRIPTION
## Summary
Updated the `--text-muted` CSS custom property to improve text contrast and readability in the application's dark theme.

## Changes
- Changed `--text-muted` color value from `#555555` to `#808080`
  - This increases the lightness of muted text elements, providing better contrast against dark backgrounds
  - Improves accessibility and readability for secondary text throughout the application

## Details
The muted text color is used for less prominent text elements in the UI. The new value (`#808080`) is lighter than the previous value (`#555555`), making it more visible while still maintaining a secondary visual hierarchy compared to primary text (`#e8e8e8`).

https://claude.ai/code/session_01SW53m56XnJrCmUEYj3adoq