### PR TITLE
feat(kitchen): faza 0 — skeleton modułu Kuchnia

### DIFF
--- a/doświadczenia.md
+++ b/doświadczenia.md
@@ -4,6 +4,16 @@ Plik prowadzony automatycznie przez Claude Code. Każdy wpis to rzeczywisty prob
 
 ---
 
+## 2026-05-21 — `trackActivity` z literal union modułów — przy nowym module trzeba rozszerzyć typ
+
+**Problem:** Stworzyłem `src/actions/recipes.ts` i `cookbooks.ts` z `trackActivity("kitchen", …)`. TypeScript rzucił `TS2345: Argument of type '"kitchen"' is not assignable to parameter of type '"shopping" | "tasks" | "notes"'` — funkcja `trackActivity` w `src/actions/activity.ts` ma sztywno wpisany literal union dla modułów.
+
+**Rozwiązanie:** Dodanie `"kitchen"` do literal union w sygnaturze `trackActivity(module: "shopping" | "tasks" | "notes" | "kitchen", …)`. Sama tabela `UserActivity.module` to `String` — DB nie wymaga zmian.
+
+**Lekcja:** Po dodaniu nowego modułu — sprawdzić wszystkie literal union typy w `src/actions/activity.ts`, `src/lib/permissions.ts`, `permissionForPath()`, `MODULES` w `AppShell.tsx`. TypeScript wyłapie większość, ale warto przejrzeć ręcznie żeby nie zaskoczyło to dopiero podczas buildu.
+
+---
+
 ## 2026-05-20 — Brakujące `teamId` w `select` po rozszerzeniu schematu
 
 **Problem:** Dodaliśmy pole `teamId` do modelu `Report` w `schema.prisma`. Typ `ReportMeta = Omit<Report, "content">` automatycznie zaczął wymagać `teamId`. Oba zapytania Prisma używały `select` bez `teamId`, więc TypeScript rzucił błąd dopiero na produkcyjnym buildzie Render — lokalnie nie było `prisma generate`.

--- a/worldofmag/package-lock.json
+++ b/worldofmag/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.2",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-collapsible": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -20,6 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.4",
+        "date-fns": "^4.2.1",
         "emoji-picker-react": "^4.19.1",
         "lucide-react": "^0.468.0",
         "next": "14.2.29",
@@ -92,6 +95,59 @@
       },
       "peerDependencies": {
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2024,6 +2080,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
+      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",

--- a/worldofmag/package.json
+++ b/worldofmag/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.2",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
@@ -24,6 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.4",
+    "date-fns": "^4.2.1",
     "emoji-picker-react": "^4.19.1",
     "lucide-react": "^0.468.0",
     "next": "14.2.29",

--- a/worldofmag/prisma/migrations/0023_kitchen_module/migration.sql
+++ b/worldofmag/prisma/migrations/0023_kitchen_module/migration.sql
@@ -1,0 +1,264 @@
+-- ─── Kitchen / Recipes module ─────────────────────────────────────────────
+
+-- Cookbook
+CREATE TABLE "Cookbook" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "emoji" TEXT NOT NULL DEFAULT '📚',
+    "color" TEXT,
+    "ownerId" TEXT,
+    "ownerTeamId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Cookbook_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "Cookbook_ownerId_idx" ON "Cookbook"("ownerId");
+CREATE INDEX "Cookbook_ownerTeamId_idx" ON "Cookbook"("ownerTeamId");
+ALTER TABLE "Cookbook" ADD CONSTRAINT "Cookbook_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Cookbook" ADD CONSTRAINT "Cookbook_ownerTeamId_fkey"
+  FOREIGN KEY ("ownerTeamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Recipe
+CREATE TABLE "Recipe" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "introMarkdown" TEXT DEFAULT '',
+    "notes" TEXT DEFAULT '',
+    "servings" INTEGER NOT NULL DEFAULT 2,
+    "prepMinutes" INTEGER,
+    "cookMinutes" INTEGER,
+    "difficulty" TEXT NOT NULL DEFAULT 'easy',
+    "cuisine" TEXT,
+    "mealType" TEXT,
+    "coverImageUrl" TEXT,
+    "ownerId" TEXT,
+    "ownerTeamId" TEXT,
+    "cookbookId" TEXT,
+    "cookCount" INTEGER NOT NULL DEFAULT 0,
+    "lastCookedAt" TIMESTAMP(3),
+    "rating" DOUBLE PRECISION,
+    "sourceUrl" TEXT,
+    "sourceType" TEXT NOT NULL DEFAULT 'manual',
+    "isPublic" BOOLEAN NOT NULL DEFAULT false,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Recipe_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "Recipe_slug_key" ON "Recipe"("slug");
+CREATE INDEX "Recipe_ownerId_idx" ON "Recipe"("ownerId");
+CREATE INDEX "Recipe_ownerTeamId_idx" ON "Recipe"("ownerTeamId");
+CREATE INDEX "Recipe_cookbookId_idx" ON "Recipe"("cookbookId");
+CREATE INDEX "Recipe_mealType_difficulty_idx" ON "Recipe"("mealType", "difficulty");
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_ownerTeamId_fkey"
+  FOREIGN KEY ("ownerTeamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_cookbookId_fkey"
+  FOREIGN KEY ("cookbookId") REFERENCES "Cookbook"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- RecipeIngredient
+CREATE TABLE "RecipeIngredient" (
+    "id" TEXT NOT NULL,
+    "recipeId" TEXT NOT NULL,
+    "productId" TEXT,
+    "name" TEXT NOT NULL,
+    "quantity" DOUBLE PRECISION,
+    "unit" TEXT,
+    "groupName" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "note" TEXT,
+    "isOptional" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "RecipeIngredient_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "RecipeIngredient_recipeId_idx" ON "RecipeIngredient"("recipeId");
+CREATE INDEX "RecipeIngredient_productId_idx" ON "RecipeIngredient"("productId");
+ALTER TABLE "RecipeIngredient" ADD CONSTRAINT "RecipeIngredient_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RecipeIngredient" ADD CONSTRAINT "RecipeIngredient_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- RecipeStep
+CREATE TABLE "RecipeStep" (
+    "id" TEXT NOT NULL,
+    "recipeId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "text" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "durationMin" INTEGER,
+    "temperature" TEXT,
+    CONSTRAINT "RecipeStep_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "RecipeStep_recipeId_order_idx" ON "RecipeStep"("recipeId", "order");
+ALTER TABLE "RecipeStep" ADD CONSTRAINT "RecipeStep_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RecipeImage
+CREATE TABLE "RecipeImage" (
+    "id" TEXT NOT NULL,
+    "recipeId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "caption" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isCover" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "RecipeImage_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "RecipeImage_recipeId_idx" ON "RecipeImage"("recipeId");
+ALTER TABLE "RecipeImage" ADD CONSTRAINT "RecipeImage_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RecipeTag (M:N na istniejącym Tag)
+CREATE TABLE "RecipeTag" (
+    "recipeId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    CONSTRAINT "RecipeTag_pkey" PRIMARY KEY ("recipeId", "tagId")
+);
+ALTER TABLE "RecipeTag" ADD CONSTRAINT "RecipeTag_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RecipeTag" ADD CONSTRAINT "RecipeTag_tagId_fkey"
+  FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RecipeRating
+CREATE TABLE "RecipeRating" (
+    "id" TEXT NOT NULL,
+    "recipeId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RecipeRating_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "RecipeRating_recipeId_userId_key" ON "RecipeRating"("recipeId", "userId");
+ALTER TABLE "RecipeRating" ADD CONSTRAINT "RecipeRating_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RecipeRating" ADD CONSTRAINT "RecipeRating_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- MealPlanEntry
+CREATE TABLE "MealPlanEntry" (
+    "id" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "slot" TEXT NOT NULL,
+    "recipeId" TEXT,
+    "customTitle" TEXT,
+    "servings" INTEGER NOT NULL DEFAULT 2,
+    "notes" TEXT,
+    "ownerId" TEXT,
+    "ownerTeamId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'PLANNED',
+    "cookedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "MealPlanEntry_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "MealPlanEntry_ownerId_date_idx" ON "MealPlanEntry"("ownerId", "date");
+CREATE INDEX "MealPlanEntry_ownerTeamId_date_idx" ON "MealPlanEntry"("ownerTeamId", "date");
+CREATE INDEX "MealPlanEntry_date_idx" ON "MealPlanEntry"("date");
+ALTER TABLE "MealPlanEntry" ADD CONSTRAINT "MealPlanEntry_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "MealPlanEntry" ADD CONSTRAINT "MealPlanEntry_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "MealPlanEntry" ADD CONSTRAINT "MealPlanEntry_ownerTeamId_fkey"
+  FOREIGN KEY ("ownerTeamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- PantryItem
+CREATE TABLE "PantryItem" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT,
+    "name" TEXT NOT NULL,
+    "quantity" DOUBLE PRECISION,
+    "unit" TEXT,
+    "location" TEXT,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "openedAt" TIMESTAMP(3),
+    "ownerId" TEXT,
+    "ownerTeamId" TEXT,
+    "minQuantity" DOUBLE PRECISION,
+    "autoShop" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "PantryItem_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "PantryItem_ownerId_idx" ON "PantryItem"("ownerId");
+CREATE INDEX "PantryItem_ownerTeamId_idx" ON "PantryItem"("ownerTeamId");
+CREATE INDEX "PantryItem_productId_idx" ON "PantryItem"("productId");
+CREATE INDEX "PantryItem_expiresAt_idx" ON "PantryItem"("expiresAt");
+ALTER TABLE "PantryItem" ADD CONSTRAINT "PantryItem_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "PantryItem" ADD CONSTRAINT "PantryItem_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PantryItem" ADD CONSTRAINT "PantryItem_ownerTeamId_fkey"
+  FOREIGN KEY ("ownerTeamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ItemRecipeOrigin (soft-link Item → Recipe)
+CREATE TABLE "ItemRecipeOrigin" (
+    "itemId" TEXT NOT NULL,
+    "recipeId" TEXT NOT NULL,
+    "servings" INTEGER NOT NULL DEFAULT 2,
+    "ingredientId" TEXT,
+    CONSTRAINT "ItemRecipeOrigin_pkey" PRIMARY KEY ("itemId")
+);
+CREATE INDEX "ItemRecipeOrigin_recipeId_idx" ON "ItemRecipeOrigin"("recipeId");
+ALTER TABLE "ItemRecipeOrigin" ADD CONSTRAINT "ItemRecipeOrigin_itemId_fkey"
+  FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ItemRecipeOrigin" ADD CONSTRAINT "ItemRecipeOrigin_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ─── Permissions seed for kitchen module ─────────────────────────────────
+
+INSERT INTO "Permission" ("id", "slug", "name", "description") VALUES
+  (gen_random_uuid()::text, 'module.kitchen',        'Kuchnia',                 'Dostęp do modułu Kuchnia'),
+  (gen_random_uuid()::text, 'kitchen.recipe.create', 'Twórz przepisy',          'Tworzenie własnych przepisów'),
+  (gen_random_uuid()::text, 'kitchen.recipe.edit',   'Edytuj własne przepisy',  'Edycja przepisów których jesteś właścicielem'),
+  (gen_random_uuid()::text, 'kitchen.recipe.delete', 'Usuwaj własne przepisy',  'Usuwanie własnych przepisów'),
+  (gen_random_uuid()::text, 'kitchen.mealplan.edit', 'Edytuj plan posiłków',    'Tworzenie i edycja wpisów planu posiłków'),
+  (gen_random_uuid()::text, 'kitchen.pantry.edit',   'Edytuj spiżarnię',        'Zarządzanie zawartością spiżarni'),
+  (gen_random_uuid()::text, 'kitchen.ai',            'Funkcje AI w Kuchni',     'Dostęp do funkcji AI w module Kuchnia (parsowanie, import, sugestie)')
+ON CONFLICT ("slug") DO NOTHING;
+
+-- USER: dostęp do modułu + CRUD własnych zasobów
+INSERT INTO "RolePermission" ("id", "role", "permissionId")
+SELECT gen_random_uuid()::text, 'USER', p."id"
+FROM "Permission" p
+WHERE p."slug" IN (
+  'module.kitchen',
+  'kitchen.recipe.create',
+  'kitchen.recipe.edit',
+  'kitchen.recipe.delete',
+  'kitchen.mealplan.edit',
+  'kitchen.pantry.edit'
+)
+ON CONFLICT ("role", "permissionId") DO NOTHING;
+
+-- BETA_TESTER: USER + AI
+INSERT INTO "RolePermission" ("id", "role", "permissionId")
+SELECT gen_random_uuid()::text, 'BETA_TESTER', p."id"
+FROM "Permission" p
+WHERE p."slug" IN (
+  'module.kitchen',
+  'kitchen.recipe.create',
+  'kitchen.recipe.edit',
+  'kitchen.recipe.delete',
+  'kitchen.mealplan.edit',
+  'kitchen.pantry.edit',
+  'kitchen.ai'
+)
+ON CONFLICT ("role", "permissionId") DO NOTHING;
+
+-- ADMIN: wszystkie nowe permissions
+INSERT INTO "RolePermission" ("id", "role", "permissionId")
+SELECT gen_random_uuid()::text, 'ADMIN', p."id"
+FROM "Permission" p
+WHERE p."slug" IN (
+  'module.kitchen',
+  'kitchen.recipe.create',
+  'kitchen.recipe.edit',
+  'kitchen.recipe.delete',
+  'kitchen.mealplan.edit',
+  'kitchen.pantry.edit',
+  'kitchen.ai'
+)
+ON CONFLICT ("role", "permissionId") DO NOTHING;

--- a/worldofmag/prisma/schema.prisma
+++ b/worldofmag/prisma/schema.prisma
@@ -17,38 +17,43 @@ model User {
   emailVerified DateTime?
   image         String?
   avatarUrl     String?
-  role          String    @default("USER")  // "USER" | "ADMIN"
+  role          String    @default("USER") // "USER" | "ADMIN"
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  accounts          Account[]
-  sessions          Session[]
-  ownedTeams        Team[]                @relation("TeamOwner")
-  teamMemberships   TeamMember[]
-  sentInvitations   TeamInvitation[]      @relation("InvitedBy")
-  receivedInvitations TeamInvitation[]    @relation("InvitedUser")
-  ownedLists        ShoppingList[]
-  products          Product[]
-  units             Unit[]
-  categories        Category[]
-  ownedTaskProjects TaskProject[]         @relation("OwnedTaskProjects")
-  taskProjectMemberships TaskProjectMember[] @relation("TaskProjectMemberships")
-  tasksCreated      Task[]               @relation("TasksCreatedBy")
-  tasksAssigned     Task[]               @relation("TasksAssignedTo")
-  taskComments      TaskComment[]        @relation("TaskComments")
-  taskShares        TaskShare[]          @relation("TaskShares")
-  activities        UserActivity[]
-  stores            Store[]
-  categoryIconVariants CategoryIconVariant[]
-  userRoles         UserRole[]
-  ownedNotes        Note[]               @relation("OwnedNotes")
-  reports           Report[]             @relation("AuthoredReports")
+  accounts               Account[]
+  sessions               Session[]
+  ownedTeams             Team[]                @relation("TeamOwner")
+  teamMemberships        TeamMember[]
+  sentInvitations        TeamInvitation[]      @relation("InvitedBy")
+  receivedInvitations    TeamInvitation[]      @relation("InvitedUser")
+  ownedLists             ShoppingList[]
+  products               Product[]
+  units                  Unit[]
+  categories             Category[]
+  ownedTaskProjects      TaskProject[]         @relation("OwnedTaskProjects")
+  taskProjectMemberships TaskProjectMember[]   @relation("TaskProjectMemberships")
+  tasksCreated           Task[]                @relation("TasksCreatedBy")
+  tasksAssigned          Task[]                @relation("TasksAssignedTo")
+  taskComments           TaskComment[]         @relation("TaskComments")
+  taskShares             TaskShare[]           @relation("TaskShares")
+  activities             UserActivity[]
+  stores                 Store[]
+  categoryIconVariants   CategoryIconVariant[]
+  userRoles              UserRole[]
+  ownedNotes             Note[]                @relation("OwnedNotes")
+  reports                Report[]              @relation("AuthoredReports")
+  recipes                Recipe[]              @relation("OwnedRecipes")
+  cookbooks              Cookbook[]            @relation("OwnedCookbooks")
+  mealPlans              MealPlanEntry[]       @relation("OwnedMealPlans")
+  pantryItems            PantryItem[]          @relation("OwnedPantryItems")
+  recipeRatings          RecipeRating[]
 }
 
 model UserRole {
   id     String @id @default(cuid())
   userId String
-  role   String  // "USER" | "ADMIN" | "BETA_TESTER"
+  role   String // "USER" | "ADMIN" | "BETA_TESTER"
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -115,36 +120,40 @@ model VerificationToken {
 // ─── Teams ────────────────────────────────────────────────────────────────
 
 model Team {
-  id          String   @id @default(cuid())
-  name        String
-  description String?
-  avatarUrl   String?
-  ownerId     String
+  id           String   @id @default(cuid())
+  name         String
+  description  String?
+  avatarUrl    String?
+  ownerId      String
   parentTeamId String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  owner       User             @relation("TeamOwner", fields: [ownerId], references: [id])
-  parentTeam  Team?            @relation("SubTeams", fields: [parentTeamId], references: [id])
-  subTeams    Team[]           @relation("SubTeams")
-  members     TeamMember[]
-  invitations TeamInvitation[]
-  lists       ShoppingList[]   @relation("TeamLists")
-  products    Product[]
-  units       Unit[]
-  categories  Category[]
-  taskProjects TaskProject[]   @relation("TeamTaskProjects")
-  taskShares  TaskShare[]      @relation("TeamTaskShares")
-  notes       Note[]           @relation("TeamNotes")
+  owner                User                  @relation("TeamOwner", fields: [ownerId], references: [id])
+  parentTeam           Team?                 @relation("SubTeams", fields: [parentTeamId], references: [id])
+  subTeams             Team[]                @relation("SubTeams")
+  members              TeamMember[]
+  invitations          TeamInvitation[]
+  lists                ShoppingList[]        @relation("TeamLists")
+  products             Product[]
+  units                Unit[]
+  categories           Category[]
+  taskProjects         TaskProject[]         @relation("TeamTaskProjects")
+  taskShares           TaskShare[]           @relation("TeamTaskShares")
+  notes                Note[]                @relation("TeamNotes")
   categoryIconVariants CategoryIconVariant[] @relation("TeamIconVariants")
-  reports     Report[]         @relation("TeamReports")
+  reports              Report[]              @relation("TeamReports")
+  recipes              Recipe[]              @relation("TeamRecipes")
+  cookbooks            Cookbook[]            @relation("TeamCookbooks")
+  mealPlans            MealPlanEntry[]       @relation("TeamMealPlans")
+  pantryItems          PantryItem[]          @relation("TeamPantryItems")
 }
 
 model TeamMember {
-  teamId    String
-  userId    String
-  role      String   @default("MEMBER")  // "MEMBER" | "ADMIN" | "OWNER"
-  joinedAt  DateTime @default(now())
+  teamId   String
+  userId   String
+  role     String   @default("MEMBER") // "MEMBER" | "ADMIN" | "OWNER"
+  joinedAt DateTime @default(now())
 
   team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -157,7 +166,7 @@ model TeamInvitation {
   teamId        String
   invitedById   String
   invitedUserId String
-  status        String   @default("PENDING")  // "PENDING" | "ACCEPTED" | "REJECTED"
+  status        String   @default("PENDING") // "PENDING" | "ACCEPTED" | "REJECTED"
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
@@ -198,7 +207,8 @@ model Item {
   updatedAt DateTime @updatedAt
   listId    String
 
-  list ShoppingList @relation(fields: [listId], references: [id], onDelete: Cascade)
+  list         ShoppingList      @relation(fields: [listId], references: [id], onDelete: Cascade)
+  recipeOrigin ItemRecipeOrigin?
 }
 
 model ItemHistory {
@@ -226,6 +236,9 @@ model Product {
 
   user User? @relation(fields: [userId], references: [id], onDelete: Cascade)
   team Team? @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  recipeIngredients RecipeIngredient[]
+  pantryItems       PantryItem[]
 }
 
 // ─── System Config ────────────────────────────────────────────────────────
@@ -300,11 +313,12 @@ model NoteGroup {
 }
 
 model Tag {
-  id        String    @id @default(cuid())
-  name      String    @unique
+  id        String      @id @default(cuid())
+  name      String      @unique
   color     String?
-  createdAt DateTime  @default(now())
+  createdAt DateTime    @default(now())
   notes     NoteTag[]
+  recipes   RecipeTag[]
 }
 
 model Note {
@@ -347,16 +361,16 @@ model TaskProject {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  owner    User?              @relation("OwnedTaskProjects", fields: [ownerId], references: [id])
-  ownerTeam Team?             @relation("TeamTaskProjects", fields: [ownerTeamId], references: [id])
-  tasks    Task[]
-  members  TaskProjectMember[]
+  owner     User?               @relation("OwnedTaskProjects", fields: [ownerId], references: [id])
+  ownerTeam Team?               @relation("TeamTaskProjects", fields: [ownerTeamId], references: [id])
+  tasks     Task[]
+  members   TaskProjectMember[]
 }
 
 model TaskProjectMember {
   projectId String
   userId    String
-  role      String   @default("MEMBER")   // MEMBER | ADMIN | OWNER
+  role      String   @default("MEMBER") // MEMBER | ADMIN | OWNER
   createdAt DateTime @default(now())
 
   project TaskProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -377,13 +391,13 @@ model Task {
   id            String    @id @default(cuid())
   title         String
   description   String?
-  status        String    @default("TODO")    // TODO | IN_PROGRESS | DONE | CANCELLED | DEFERRED
-  priority      String    @default("NONE")    // NONE | LOW | MEDIUM | HIGH | URGENT
+  status        String    @default("TODO") // TODO | IN_PROGRESS | DONE | CANCELLED | DEFERRED
+  priority      String    @default("NONE") // NONE | LOW | MEDIUM | HIGH | URGENT
   dueDate       DateTime?
   startDate     DateTime?
   completedAt   DateTime?
   estimatedMins Int?
-  recurring     String?                        // JSON: RecurringRule
+  recurring     String? // JSON: RecurringRule
   category      String    @default("Other")
   order         Float     @default(0)
   projectId     String?
@@ -393,14 +407,14 @@ model Task {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  project      TaskProject? @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  parent       Task?        @relation("TaskSubtasks", fields: [parentTaskId], references: [id], onDelete: SetNull)
-  subtasks     Task[]       @relation("TaskSubtasks")
-  createdBy    User?        @relation("TasksCreatedBy", fields: [createdById], references: [id])
-  assignee     User?        @relation("TasksAssignedTo", fields: [assigneeId], references: [id])
-  tags         TaskTaskTag[]
-  comments     TaskComment[]
-  shares       TaskShare[]
+  project   TaskProject?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  parent    Task?         @relation("TaskSubtasks", fields: [parentTaskId], references: [id], onDelete: SetNull)
+  subtasks  Task[]        @relation("TaskSubtasks")
+  createdBy User?         @relation("TasksCreatedBy", fields: [createdById], references: [id])
+  assignee  User?         @relation("TasksAssignedTo", fields: [assigneeId], references: [id])
+  tags      TaskTaskTag[]
+  comments  TaskComment[]
+  shares    TaskShare[]
 }
 
 model TaskTaskTag {
@@ -430,7 +444,7 @@ model TaskShare {
   taskId    String
   userId    String?
   teamId    String?
-  role      String   @default("VIEWER")    // VIEWER | EDITOR
+  role      String   @default("VIEWER") // VIEWER | EDITOR
   createdAt DateTime @default(now())
 
   task Task  @relation(fields: [taskId], references: [id], onDelete: Cascade)
@@ -444,8 +458,8 @@ model UserActivity {
   id        String   @id @default(cuid())
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  module    String   // "shopping" | "tasks" | "notes"
-  action    String   // "add_item" | "create_task" | "create_note" | etc.
+  module    String // "shopping" | "tasks" | "notes"
+  action    String // "add_item" | "create_task" | "create_note" | etc.
   metadata  Json?
   createdAt DateTime @default(now())
 
@@ -496,7 +510,7 @@ model Report {
   id        String   @id @default(cuid())
   title     String
   slug      String   @unique
-  content   String   // markdown content
+  content   String // markdown content
   category  String   @default("general")
   authorId  String?
   teamId    String?
@@ -508,4 +522,199 @@ model Report {
   @@index([category, createdAt])
   @@index([authorId])
   @@index([teamId])
+}
+
+// ─── Kitchen / Recipes ────────────────────────────────────────────────────
+
+model Recipe {
+  id            String    @id @default(cuid())
+  title         String
+  slug          String    @unique
+  description   String?
+  introMarkdown String?   @default("")
+  notes         String?   @default("")
+  servings      Int       @default(2)
+  prepMinutes   Int?
+  cookMinutes   Int?
+  difficulty    String    @default("easy")
+  cuisine       String?
+  mealType      String?
+  coverImageUrl String?
+  ownerId       String?
+  ownerTeamId   String?
+  cookbookId    String?
+  cookCount     Int       @default(0)
+  lastCookedAt  DateTime?
+  rating        Float?
+  sourceUrl     String?
+  sourceType    String    @default("manual")
+  isPublic      Boolean   @default(false)
+  isArchived    Boolean   @default(false)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  owner          User?              @relation("OwnedRecipes", fields: [ownerId], references: [id], onDelete: SetNull)
+  ownerTeam      Team?              @relation("TeamRecipes", fields: [ownerTeamId], references: [id], onDelete: SetNull)
+  cookbook       Cookbook?          @relation(fields: [cookbookId], references: [id], onDelete: SetNull)
+  ingredients    RecipeIngredient[]
+  steps          RecipeStep[]
+  images         RecipeImage[]
+  tags           RecipeTag[]
+  plannedMeals   MealPlanEntry[]
+  ratings        RecipeRating[]
+  itemsGenerated ItemRecipeOrigin[] @relation("ItemsFromRecipe")
+
+  @@index([ownerId])
+  @@index([ownerTeamId])
+  @@index([cookbookId])
+  @@index([mealType, difficulty])
+}
+
+model RecipeIngredient {
+  id         String  @id @default(cuid())
+  recipeId   String
+  productId  String?
+  name       String
+  quantity   Float?
+  unit       String?
+  groupName  String?
+  order      Int     @default(0)
+  note       String?
+  isOptional Boolean @default(false)
+
+  recipe  Recipe   @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+  product Product? @relation(fields: [productId], references: [id], onDelete: SetNull)
+
+  @@index([recipeId])
+  @@index([productId])
+}
+
+model RecipeStep {
+  id          String  @id @default(cuid())
+  recipeId    String
+  order       Int
+  text        String
+  imageUrl    String?
+  durationMin Int?
+  temperature String?
+
+  recipe Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+
+  @@index([recipeId, order])
+}
+
+model RecipeImage {
+  id       String  @id @default(cuid())
+  recipeId String
+  url      String
+  caption  String?
+  order    Int     @default(0)
+  isCover  Boolean @default(false)
+
+  recipe Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+
+  @@index([recipeId])
+}
+
+model RecipeTag {
+  recipeId String
+  tagId    String
+  recipe   Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+  tag      Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([recipeId, tagId])
+}
+
+model RecipeRating {
+  id        String   @id @default(cuid())
+  recipeId  String
+  userId    String
+  value     Int
+  comment   String?
+  createdAt DateTime @default(now())
+
+  recipe Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([recipeId, userId])
+}
+
+model Cookbook {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  emoji       String   @default("📚")
+  color       String?
+  ownerId     String?
+  ownerTeamId String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  owner     User?    @relation("OwnedCookbooks", fields: [ownerId], references: [id], onDelete: SetNull)
+  ownerTeam Team?    @relation("TeamCookbooks", fields: [ownerTeamId], references: [id], onDelete: SetNull)
+  recipes   Recipe[]
+
+  @@index([ownerId])
+  @@index([ownerTeamId])
+}
+
+model MealPlanEntry {
+  id          String    @id @default(cuid())
+  date        DateTime
+  slot        String
+  recipeId    String?
+  customTitle String?
+  servings    Int       @default(2)
+  notes       String?
+  ownerId     String?
+  ownerTeamId String?
+  status      String    @default("PLANNED")
+  cookedAt    DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  recipe    Recipe? @relation(fields: [recipeId], references: [id], onDelete: SetNull)
+  owner     User?   @relation("OwnedMealPlans", fields: [ownerId], references: [id], onDelete: SetNull)
+  ownerTeam Team?   @relation("TeamMealPlans", fields: [ownerTeamId], references: [id], onDelete: SetNull)
+
+  @@index([ownerId, date])
+  @@index([ownerTeamId, date])
+  @@index([date])
+}
+
+model PantryItem {
+  id          String    @id @default(cuid())
+  productId   String?
+  name        String
+  quantity    Float?
+  unit        String?
+  location    String?
+  addedAt     DateTime  @default(now())
+  expiresAt   DateTime?
+  openedAt    DateTime?
+  ownerId     String?
+  ownerTeamId String?
+  minQuantity Float?
+  autoShop    Boolean   @default(false)
+
+  product   Product? @relation(fields: [productId], references: [id], onDelete: SetNull)
+  owner     User?    @relation("OwnedPantryItems", fields: [ownerId], references: [id], onDelete: Cascade)
+  ownerTeam Team?    @relation("TeamPantryItems", fields: [ownerTeamId], references: [id], onDelete: Cascade)
+
+  @@index([ownerId])
+  @@index([ownerTeamId])
+  @@index([productId])
+  @@index([expiresAt])
+}
+
+model ItemRecipeOrigin {
+  itemId       String  @id
+  recipeId     String
+  servings     Int     @default(2)
+  ingredientId String?
+
+  item   Item   @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  recipe Recipe @relation("ItemsFromRecipe", fields: [recipeId], references: [id], onDelete: Cascade)
+
+  @@index([recipeId])
 }

--- a/worldofmag/src/actions/activity.ts
+++ b/worldofmag/src/actions/activity.ts
@@ -5,7 +5,7 @@ import { auth } from "@/lib/auth";
 import type { Prisma } from "@prisma/client";
 
 export async function trackActivity(
-  module: "shopping" | "tasks" | "notes",
+  module: "shopping" | "tasks" | "notes" | "kitchen",
   action: string,
   metadata?: Record<string, unknown>
 ): Promise<void> {

--- a/worldofmag/src/actions/cookbooks.ts
+++ b/worldofmag/src/actions/cookbooks.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, getUserTeamIds } from "@/lib/server-utils";
+import { trackActivity } from "@/actions/activity";
+import type { Cookbook } from "@/types/kitchen";
+
+export type CookbookWithCount = Cookbook & { recipeCount: number };
+
+export async function assertCookbookAccess(cookbookId: string, userId: string): Promise<void> {
+  const teamIds = await getUserTeamIds(userId);
+  const cb = await prisma.cookbook.findUnique({
+    where: { id: cookbookId },
+    select: { ownerId: true, ownerTeamId: true },
+  });
+  if (!cb) throw new Error("Książka kucharska nie istnieje");
+  if (cb.ownerId === userId) return;
+  if (cb.ownerTeamId && teamIds.includes(cb.ownerTeamId)) return;
+  throw new Error("Brak dostępu do tej książki kucharskiej");
+}
+
+export async function getCookbooks(): Promise<CookbookWithCount[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const cookbooks = await prisma.cookbook.findMany({
+    where: {
+      OR: [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ],
+    },
+    orderBy: { createdAt: "asc" },
+    include: { _count: { select: { recipes: true } } },
+  });
+
+  return cookbooks.map((cb) => {
+    const { _count, ...rest } = cb;
+    return { ...rest, recipeCount: _count.recipes };
+  });
+}
+
+export async function createCookbook(data: {
+  name: string;
+  description?: string | null;
+  emoji?: string;
+  color?: string | null;
+  ownerTeamId?: string | null;
+}): Promise<Cookbook> {
+  const user = await requireAuth();
+
+  if (data.ownerTeamId) {
+    const teamIds = await getUserTeamIds(user.id);
+    if (!teamIds.includes(data.ownerTeamId)) throw new Error("Nie jesteś członkiem tego teamu");
+  }
+
+  const cb = await prisma.cookbook.create({
+    data: {
+      name: data.name.trim(),
+      description: data.description ?? null,
+      emoji: data.emoji?.trim() || "📚",
+      color: data.color ?? null,
+      ownerId: data.ownerTeamId ? null : user.id,
+      ownerTeamId: data.ownerTeamId ?? null,
+    },
+  });
+
+  void trackActivity("kitchen", "create_cookbook", { id: cb.id, name: cb.name });
+  revalidatePath("/kitchen/cookbooks");
+  revalidatePath("/kitchen/recipes");
+  return cb;
+}
+
+export async function updateCookbook(
+  id: string,
+  patch: { name?: string; description?: string | null; emoji?: string; color?: string | null }
+): Promise<Cookbook> {
+  const user = await requireAuth();
+  await assertCookbookAccess(id, user.id);
+
+  const data: Record<string, unknown> = { ...patch };
+  if (patch.name) data.name = patch.name.trim();
+
+  const cb = await prisma.cookbook.update({ where: { id }, data });
+  revalidatePath("/kitchen/cookbooks");
+  revalidatePath(`/kitchen/cookbooks/${id}`);
+  return cb;
+}
+
+export async function deleteCookbook(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertCookbookAccess(id, user.id);
+  await prisma.cookbook.delete({ where: { id } });
+  revalidatePath("/kitchen/cookbooks");
+  revalidatePath("/kitchen/recipes");
+}

--- a/worldofmag/src/actions/mealPlans.ts
+++ b/worldofmag/src/actions/mealPlans.ts
@@ -1,0 +1,385 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, getUserTeamIds } from "@/lib/server-utils";
+import { categorize } from "@/lib/categorize";
+import { trackActivity } from "@/actions/activity";
+import { assertListAccess } from "@/actions/lists";
+import type { MealSlot, MealStatus } from "@/types/kitchen";
+import type { MealPlanEntry, Item } from "@prisma/client";
+
+export type MealPlanEntryWithRecipe = MealPlanEntry & {
+  recipe: {
+    id: string;
+    slug: string;
+    title: string;
+    coverImageUrl: string | null;
+    prepMinutes: number | null;
+    cookMinutes: number | null;
+    servings: number;
+  } | null;
+};
+
+// ─── Access ───────────────────────────────────────────────────────────────
+
+async function assertMealPlanAccess(entryId: string, userId: string): Promise<void> {
+  const teamIds = await getUserTeamIds(userId);
+  const entry = await prisma.mealPlanEntry.findUnique({
+    where: { id: entryId },
+    select: { ownerId: true, ownerTeamId: true },
+  });
+  if (!entry) throw new Error("Wpis planu nie istnieje");
+  if (entry.ownerId === userId) return;
+  if (entry.ownerTeamId && teamIds.includes(entry.ownerTeamId)) return;
+  throw new Error("Brak dostępu do tego wpisu planu");
+}
+
+// ─── Date helpers ─────────────────────────────────────────────────────────
+
+function startOfDayUTC(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(12, 0, 0, 0);
+  return d;
+}
+
+// ─── Listing ──────────────────────────────────────────────────────────────
+
+export async function getMealPlan(
+  range: { from: Date; to: Date },
+  teamId?: string
+): Promise<MealPlanEntryWithRecipe[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const ownershipFilter = teamId
+    ? teamIds.includes(teamId)
+      ? [{ ownerTeamId: teamId }]
+      : []
+    : [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ];
+
+  if (ownershipFilter.length === 0) return [];
+
+  const entries = await prisma.mealPlanEntry.findMany({
+    where: {
+      AND: [
+        { OR: ownershipFilter },
+        { date: { gte: range.from, lte: range.to } },
+      ],
+    },
+    include: {
+      recipe: {
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          coverImageUrl: true,
+          prepMinutes: true,
+          cookMinutes: true,
+          servings: true,
+        },
+      },
+    },
+    orderBy: [{ date: "asc" }, { slot: "asc" }],
+  });
+
+  return entries;
+}
+
+export async function getTodaysMeals(): Promise<MealPlanEntryWithRecipe[]> {
+  const today = new Date();
+  const from = new Date(today);
+  from.setHours(0, 0, 0, 0);
+  const to = new Date(today);
+  to.setHours(23, 59, 59, 999);
+  return getMealPlan({ from, to });
+}
+
+// ─── CRUD ─────────────────────────────────────────────────────────────────
+
+export interface MealPlanEntryInput {
+  date: Date;
+  slot: MealSlot;
+  recipeId?: string | null;
+  customTitle?: string | null;
+  servings?: number;
+  notes?: string | null;
+  teamId?: string | null;
+}
+
+export async function setMealPlanEntry(data: MealPlanEntryInput): Promise<MealPlanEntry> {
+  const user = await requireAuth();
+
+  if (data.teamId) {
+    const teamIds = await getUserTeamIds(user.id);
+    if (!teamIds.includes(data.teamId)) throw new Error("Nie jesteś członkiem tego teamu");
+  }
+
+  if (!data.recipeId && !data.customTitle?.trim()) {
+    throw new Error("Wybierz przepis lub wpisz własny tytuł");
+  }
+
+  const date = startOfDayUTC(data.date);
+
+  const entry = await prisma.mealPlanEntry.create({
+    data: {
+      date,
+      slot: data.slot,
+      recipeId: data.recipeId ?? null,
+      customTitle: data.customTitle?.trim() || null,
+      servings: data.servings ?? 2,
+      notes: data.notes?.trim() || null,
+      ownerId: data.teamId ? null : user.id,
+      ownerTeamId: data.teamId ?? null,
+    },
+  });
+
+  void trackActivity("kitchen", "create_meal_plan_entry", {
+    id: entry.id,
+    date: date.toISOString(),
+    slot: data.slot,
+  });
+  revalidatePath("/kitchen/plan");
+  revalidatePath("/");
+  return entry;
+}
+
+export async function updateMealPlanEntry(
+  id: string,
+  patch: Partial<Omit<MealPlanEntryInput, "teamId">> & { status?: MealStatus }
+): Promise<MealPlanEntry> {
+  const user = await requireAuth();
+  await assertMealPlanAccess(id, user.id);
+
+  const data: Record<string, unknown> = {};
+  if (patch.date) data.date = startOfDayUTC(patch.date);
+  if (patch.slot) data.slot = patch.slot;
+  if (patch.recipeId !== undefined) data.recipeId = patch.recipeId;
+  if (patch.customTitle !== undefined) data.customTitle = patch.customTitle?.trim() || null;
+  if (patch.servings != null) data.servings = patch.servings;
+  if (patch.notes !== undefined) data.notes = patch.notes?.trim() || null;
+  if (patch.status) {
+    data.status = patch.status;
+    if (patch.status === "COOKED") data.cookedAt = new Date();
+  }
+
+  const entry = await prisma.mealPlanEntry.update({ where: { id }, data });
+  revalidatePath("/kitchen/plan");
+  revalidatePath("/");
+  return entry;
+}
+
+export async function deleteMealPlanEntry(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertMealPlanAccess(id, user.id);
+  await prisma.mealPlanEntry.delete({ where: { id } });
+  revalidatePath("/kitchen/plan");
+  revalidatePath("/");
+}
+
+export async function markMealCooked(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertMealPlanAccess(id, user.id);
+
+  const entry = await prisma.mealPlanEntry.update({
+    where: { id },
+    data: { status: "COOKED", cookedAt: new Date() },
+  });
+
+  if (entry.recipeId) {
+    await prisma.recipe.update({
+      where: { id: entry.recipeId },
+      data: { cookCount: { increment: 1 }, lastCookedAt: new Date() },
+    });
+  }
+
+  revalidatePath("/kitchen/plan");
+  revalidatePath("/kitchen/recipes");
+  revalidatePath("/");
+}
+
+export async function markMealSkipped(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertMealPlanAccess(id, user.id);
+  await prisma.mealPlanEntry.update({ where: { id }, data: { status: "SKIPPED" } });
+  revalidatePath("/kitchen/plan");
+}
+
+// ─── Move entry (drag-and-drop) ───────────────────────────────────────────
+
+export async function moveMealPlanEntry(
+  id: string,
+  targetDate: Date,
+  targetSlot: MealSlot
+): Promise<MealPlanEntry> {
+  const user = await requireAuth();
+  await assertMealPlanAccess(id, user.id);
+  const entry = await prisma.mealPlanEntry.update({
+    where: { id },
+    data: { date: startOfDayUTC(targetDate), slot: targetSlot },
+  });
+  revalidatePath("/kitchen/plan");
+  return entry;
+}
+
+// ─── Generate shopping list from plan ─────────────────────────────────────
+
+export interface GenerateShoppingListInput {
+  from: Date;
+  to: Date;
+  listId: string;
+  skipPantry?: boolean;
+  consolidate?: boolean;
+  skipOptional?: boolean;
+}
+
+export interface GenerateShoppingListResult {
+  addedItems: Item[];
+  skippedFromPantry: Array<{ name: string; quantity: number | null }>;
+  mergedCount: number;
+}
+
+interface AggregatedItem {
+  name: string;
+  productId: string | null;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  sources: Array<{ recipeId: string; ingredientId: string; servings: number }>;
+}
+
+export async function generateShoppingListFromPlan(
+  input: GenerateShoppingListInput
+): Promise<GenerateShoppingListResult> {
+  const user = await requireAuth();
+  await assertListAccess(input.listId, user.id);
+  const teamIds = await getUserTeamIds(user.id);
+
+  const ownership = [
+    { ownerId: user.id },
+    ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+  ];
+
+  const entries = await prisma.mealPlanEntry.findMany({
+    where: {
+      AND: [
+        { OR: ownership },
+        { date: { gte: input.from, lte: input.to } },
+        { recipeId: { not: null } },
+        { status: { not: "SKIPPED" } },
+      ],
+    },
+    include: {
+      recipe: {
+        include: { ingredients: { include: { product: true } } },
+      },
+    },
+  });
+
+  const pantry = input.skipPantry
+    ? await prisma.pantryItem.findMany({
+        where: { OR: ownership },
+      })
+    : [];
+
+  function pantryHas(name: string, productId: string | null): boolean {
+    return pantry.some((p) => {
+      if (productId && p.productId === productId) return (p.quantity ?? 0) > 0;
+      return p.name.toLowerCase() === name.toLowerCase() && (p.quantity ?? 0) > 0;
+    });
+  }
+
+  const consolidated = new Map<string, AggregatedItem>();
+  const passthrough: AggregatedItem[] = [];
+
+  for (const entry of entries) {
+    if (!entry.recipe) continue;
+    const scale = entry.recipe.servings > 0 ? entry.servings / entry.recipe.servings : 1;
+
+    for (const ing of entry.recipe.ingredients) {
+      if (input.skipOptional && ing.isOptional) continue;
+
+      const baseName = ing.product?.name ?? ing.name;
+      const unit = ing.unit ?? ing.product?.defaultUnit ?? null;
+      const category = ing.product?.category ?? categorize(baseName);
+      const scaledQty = ing.quantity != null ? Math.round(ing.quantity * scale * 100) / 100 : null;
+
+      const key = input.consolidate
+        ? `${(ing.productId ?? baseName.toLowerCase())}::${unit ?? ""}`
+        : null;
+
+      const aggItem: AggregatedItem = {
+        name: baseName,
+        productId: ing.productId,
+        quantity: scaledQty,
+        unit,
+        category,
+        sources: [{ recipeId: entry.recipe.id, ingredientId: ing.id, servings: entry.servings }],
+      };
+
+      if (key && consolidated.has(key)) {
+        const existing = consolidated.get(key)!;
+        if (existing.quantity != null && scaledQty != null) {
+          existing.quantity = Math.round((existing.quantity + scaledQty) * 100) / 100;
+        } else if (scaledQty != null) {
+          existing.quantity = scaledQty;
+        }
+        existing.sources.push(...aggItem.sources);
+      } else if (key) {
+        consolidated.set(key, aggItem);
+      } else {
+        passthrough.push(aggItem);
+      }
+    }
+  }
+
+  const allItems = [...Array.from(consolidated.values()), ...passthrough];
+  const initialCount = entries.reduce((sum, e) => sum + (e.recipe?.ingredients.length ?? 0), 0);
+  const mergedCount = Math.max(0, initialCount - allItems.length);
+
+  const added: Item[] = [];
+  const skippedFromPantry: Array<{ name: string; quantity: number | null }> = [];
+
+  for (const item of allItems) {
+    if (input.skipPantry && pantryHas(item.name, item.productId)) {
+      skippedFromPantry.push({ name: item.name, quantity: item.quantity });
+      continue;
+    }
+
+    const created = await prisma.item.create({
+      data: {
+        listId: input.listId,
+        name: item.name,
+        quantity: item.quantity,
+        unit: item.unit,
+        category: item.category,
+        recipeOrigin: item.sources[0]
+          ? {
+              create: {
+                recipeId: item.sources[0].recipeId,
+                ingredientId: item.sources[0].ingredientId,
+                servings: item.sources[0].servings,
+              },
+            }
+          : undefined,
+      },
+    });
+    added.push(created);
+  }
+
+  void trackActivity("kitchen", "generate_shopping_list_from_plan", {
+    listId: input.listId,
+    from: input.from.toISOString(),
+    to: input.to.toISOString(),
+    addedCount: added.length,
+    mergedCount,
+  });
+
+  revalidatePath(`/shopping/${input.listId}`);
+  revalidatePath("/kitchen/plan");
+
+  return { addedItems: added, skippedFromPantry, mergedCount };
+}

--- a/worldofmag/src/actions/pantry.ts
+++ b/worldofmag/src/actions/pantry.ts
@@ -1,0 +1,322 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, getUserTeamIds } from "@/lib/server-utils";
+import { categorize } from "@/lib/categorize";
+import { trackActivity } from "@/actions/activity";
+import { assertListAccess } from "@/actions/lists";
+import type { PantryItem, Item } from "@prisma/client";
+
+export type PantryItemWithProduct = PantryItem & {
+  product: {
+    id: string;
+    name: string;
+    category: string;
+    defaultUnit: string | null;
+  } | null;
+};
+
+async function assertPantryItemAccess(pantryItemId: string, userId: string): Promise<void> {
+  const teamIds = await getUserTeamIds(userId);
+  const item = await prisma.pantryItem.findUnique({
+    where: { id: pantryItemId },
+    select: { ownerId: true, ownerTeamId: true },
+  });
+  if (!item) throw new Error("Pozycja w spiżarni nie istnieje");
+  if (item.ownerId === userId) return;
+  if (item.ownerTeamId && teamIds.includes(item.ownerTeamId)) return;
+  throw new Error("Brak dostępu do tej pozycji");
+}
+
+// ─── Read ─────────────────────────────────────────────────────────────────
+
+export async function getPantry(teamId?: string): Promise<PantryItemWithProduct[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const ownership = teamId
+    ? teamIds.includes(teamId)
+      ? [{ ownerTeamId: teamId }]
+      : []
+    : [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ];
+
+  if (ownership.length === 0) return [];
+
+  return prisma.pantryItem.findMany({
+    where: { OR: ownership },
+    include: {
+      product: {
+        select: { id: true, name: true, category: true, defaultUnit: true },
+      },
+    },
+    orderBy: [{ location: "asc" }, { name: "asc" }],
+  });
+}
+
+export async function getExpiringSoon(days: number): Promise<PantryItemWithProduct[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() + days);
+
+  return prisma.pantryItem.findMany({
+    where: {
+      OR: [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ],
+      expiresAt: { not: null, lte: threshold },
+    },
+    include: {
+      product: { select: { id: true, name: true, category: true, defaultUnit: true } },
+    },
+    orderBy: { expiresAt: "asc" },
+  });
+}
+
+export async function getAutoReplenishCandidates(): Promise<PantryItemWithProduct[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const items = await prisma.pantryItem.findMany({
+    where: {
+      OR: [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ],
+      autoShop: true,
+      minQuantity: { not: null },
+    },
+    include: {
+      product: { select: { id: true, name: true, category: true, defaultUnit: true } },
+    },
+  });
+
+  return items.filter((i) => (i.quantity ?? 0) < (i.minQuantity ?? 0));
+}
+
+// ─── Write ────────────────────────────────────────────────────────────────
+
+export interface PantryItemInput {
+  name: string;
+  productId?: string | null;
+  quantity?: number | null;
+  unit?: string | null;
+  location?: string | null;
+  expiresAt?: Date | null;
+  openedAt?: Date | null;
+  minQuantity?: number | null;
+  autoShop?: boolean;
+  teamId?: string | null;
+}
+
+export async function addPantryItem(data: PantryItemInput): Promise<PantryItem> {
+  const user = await requireAuth();
+
+  if (data.teamId) {
+    const teamIds = await getUserTeamIds(user.id);
+    if (!teamIds.includes(data.teamId)) throw new Error("Nie jesteś członkiem tego teamu");
+  }
+
+  const created = await prisma.pantryItem.create({
+    data: {
+      name: data.name.trim(),
+      productId: data.productId ?? null,
+      quantity: data.quantity ?? null,
+      unit: data.unit ?? null,
+      location: data.location ?? null,
+      expiresAt: data.expiresAt ?? null,
+      openedAt: data.openedAt ?? null,
+      minQuantity: data.minQuantity ?? null,
+      autoShop: data.autoShop ?? false,
+      ownerId: data.teamId ? null : user.id,
+      ownerTeamId: data.teamId ?? null,
+    },
+  });
+
+  void trackActivity("kitchen", "add_pantry_item", { id: created.id, name: created.name });
+  revalidatePath("/kitchen/pantry");
+  revalidatePath("/");
+  return created;
+}
+
+export async function updatePantryItem(
+  id: string,
+  patch: Partial<Omit<PantryItemInput, "teamId">>
+): Promise<PantryItem> {
+  const user = await requireAuth();
+  await assertPantryItemAccess(id, user.id);
+
+  const data: Record<string, unknown> = {};
+  if (patch.name) data.name = patch.name.trim();
+  if (patch.productId !== undefined) data.productId = patch.productId;
+  if (patch.quantity !== undefined) data.quantity = patch.quantity;
+  if (patch.unit !== undefined) data.unit = patch.unit;
+  if (patch.location !== undefined) data.location = patch.location;
+  if (patch.expiresAt !== undefined) data.expiresAt = patch.expiresAt;
+  if (patch.openedAt !== undefined) data.openedAt = patch.openedAt;
+  if (patch.minQuantity !== undefined) data.minQuantity = patch.minQuantity;
+  if (patch.autoShop !== undefined) data.autoShop = patch.autoShop;
+
+  const updated = await prisma.pantryItem.update({ where: { id }, data });
+  revalidatePath("/kitchen/pantry");
+  revalidatePath("/");
+  return updated;
+}
+
+export async function deletePantryItem(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertPantryItemAccess(id, user.id);
+  await prisma.pantryItem.delete({ where: { id } });
+  revalidatePath("/kitchen/pantry");
+  revalidatePath("/");
+}
+
+export async function consumePantryItem(id: string, quantity: number): Promise<PantryItem> {
+  const user = await requireAuth();
+  await assertPantryItemAccess(id, user.id);
+  const existing = await prisma.pantryItem.findUnique({ where: { id } });
+  if (!existing) throw new Error("Pozycja nie istnieje");
+
+  const next = Math.max(0, (existing.quantity ?? 0) - quantity);
+  return prisma.pantryItem.update({
+    where: { id },
+    data: { quantity: next },
+  });
+}
+
+export async function setPantryQuantity(id: string, quantity: number): Promise<PantryItem> {
+  const user = await requireAuth();
+  await assertPantryItemAccess(id, user.id);
+  const updated = await prisma.pantryItem.update({
+    where: { id },
+    data: { quantity },
+  });
+  revalidatePath("/kitchen/pantry");
+  return updated;
+}
+
+export async function bulkSetPantryQuantities(
+  updates: Array<{ id: string; quantity: number | null }>
+): Promise<void> {
+  const user = await requireAuth();
+  await prisma.$transaction(async (tx) => {
+    for (const u of updates) {
+      const item = await tx.pantryItem.findUnique({
+        where: { id: u.id },
+        select: { ownerId: true, ownerTeamId: true },
+      });
+      if (!item) continue;
+      if (item.ownerId !== user.id) {
+        const teamIds = await getUserTeamIds(user.id);
+        if (!item.ownerTeamId || !teamIds.includes(item.ownerTeamId)) {
+          throw new Error("Brak dostępu do pozycji");
+        }
+      }
+      await tx.pantryItem.update({
+        where: { id: u.id },
+        data: { quantity: u.quantity },
+      });
+    }
+  });
+  revalidatePath("/kitchen/pantry");
+}
+
+// ─── Integration with shopping ────────────────────────────────────────────
+
+export async function moveItemToPantry(
+  itemId: string,
+  pantryData?: Partial<PantryItemInput>
+): Promise<PantryItem> {
+  const user = await requireAuth();
+  const item = await prisma.item.findUnique({ where: { id: itemId } });
+  if (!item) throw new Error("Pozycja zakupowa nie istnieje");
+  await assertListAccess(item.listId, user.id);
+
+  const productId =
+    pantryData?.productId ??
+    (await prisma.product.findFirst({
+      where: { name: { equals: item.name, mode: "insensitive" } },
+      select: { id: true },
+    }))?.id ??
+    null;
+
+  // If team-shared list, prefer team ownership for pantry too
+  const list = await prisma.shoppingList.findUnique({
+    where: { id: item.listId },
+    select: { ownerTeamId: true },
+  });
+
+  const teamId = pantryData?.teamId ?? list?.ownerTeamId ?? null;
+
+  // Look for existing pantry item with same productId or name
+  const existing = await prisma.pantryItem.findFirst({
+    where: {
+      AND: [
+        productId ? { productId } : { name: { equals: item.name, mode: "insensitive" } },
+        teamId ? { ownerTeamId: teamId } : { ownerId: user.id },
+      ],
+    },
+  });
+
+  if (existing) {
+    const added = item.quantity ?? 0;
+    const updated = await prisma.pantryItem.update({
+      where: { id: existing.id },
+      data: {
+        quantity: (existing.quantity ?? 0) + added,
+        unit: existing.unit ?? item.unit,
+      },
+    });
+    revalidatePath("/kitchen/pantry");
+    return updated;
+  }
+
+  const created = await prisma.pantryItem.create({
+    data: {
+      name: pantryData?.name ?? item.name,
+      productId,
+      quantity: pantryData?.quantity ?? item.quantity,
+      unit: pantryData?.unit ?? item.unit,
+      location: pantryData?.location ?? null,
+      ownerId: teamId ? null : user.id,
+      ownerTeamId: teamId,
+    },
+  });
+  revalidatePath("/kitchen/pantry");
+  return created;
+}
+
+export async function autoReplenishToList(listId: string): Promise<{ addedItems: Item[] }> {
+  const user = await requireAuth();
+  await assertListAccess(listId, user.id);
+
+  const candidates = await getAutoReplenishCandidates();
+  const added: Item[] = [];
+
+  for (const c of candidates) {
+    const deficit =
+      c.minQuantity != null
+        ? Math.max(c.minQuantity - (c.quantity ?? 0), c.minQuantity)
+        : null;
+    const created = await prisma.item.create({
+      data: {
+        listId,
+        name: c.product?.name ?? c.name,
+        quantity: deficit ?? null,
+        unit: c.unit ?? c.product?.defaultUnit ?? null,
+        category: c.product?.category ?? categorize(c.name),
+      },
+    });
+    added.push(created);
+  }
+
+  void trackActivity("kitchen", "auto_replenish", { listId, count: added.length });
+  revalidatePath(`/shopping/${listId}`);
+  return { addedItems: added };
+}

--- a/worldofmag/src/actions/recipes.ts
+++ b/worldofmag/src/actions/recipes.ts
@@ -1,0 +1,632 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, getUserTeamIds } from "@/lib/server-utils";
+import { categorize } from "@/lib/categorize";
+import { trackActivity } from "@/actions/activity";
+import { assertListAccess } from "@/actions/lists";
+import type {
+  RecipeListItem,
+  RecipeFull,
+  CreateRecipeInput,
+  UpdateRecipeInput,
+  IngredientInput,
+  StepInput,
+  MealType,
+  Difficulty,
+} from "@/types/kitchen";
+import type { Recipe, RecipeIngredient, RecipeStep, Item } from "@prisma/client";
+
+// ─── Access control ───────────────────────────────────────────────────────
+
+export async function assertRecipeAccess(
+  recipeId: string,
+  userId: string,
+  mode: "read" | "edit" = "edit"
+): Promise<void> {
+  const teamIds = await getUserTeamIds(userId);
+  const recipe = await prisma.recipe.findUnique({
+    where: { id: recipeId },
+    select: { ownerId: true, ownerTeamId: true, isPublic: true },
+  });
+  if (!recipe) throw new Error("Przepis nie istnieje");
+  if (recipe.ownerId === userId) return;
+  if (recipe.ownerTeamId && teamIds.includes(recipe.ownerTeamId)) return;
+  if (mode === "read" && recipe.isPublic) return;
+  throw new Error("Brak dostępu do tego przepisu");
+}
+
+// ─── Slug helpers ─────────────────────────────────────────────────────────
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/ł/g, "l")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "przepis";
+}
+
+async function uniqueSlug(title: string, existingId?: string): Promise<string> {
+  const base = slugify(title);
+  let slug = base;
+  let i = 1;
+  while (true) {
+    const found = await prisma.recipe.findUnique({ where: { slug } });
+    if (!found || found.id === existingId) return slug;
+    i += 1;
+    slug = `${base}-${i}`;
+  }
+}
+
+// ─── Listing & detail ─────────────────────────────────────────────────────
+
+export async function getRecipes(opts?: {
+  search?: string;
+  tagIds?: string[];
+  cookbookId?: string;
+  cuisine?: string;
+  mealType?: MealType;
+  maxMinutes?: number;
+  ownedOnly?: boolean;
+}): Promise<RecipeListItem[]> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const ownership = opts?.ownedOnly
+    ? [{ ownerId: user.id }]
+    : [
+        { ownerId: user.id },
+        ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+      ];
+
+  const where: Record<string, unknown> = {
+    isArchived: false,
+    OR: ownership,
+  };
+
+  if (opts?.cookbookId) where.cookbookId = opts.cookbookId;
+  if (opts?.cuisine) where.cuisine = opts.cuisine;
+  if (opts?.mealType) where.mealType = opts.mealType;
+  if (opts?.tagIds && opts.tagIds.length > 0) {
+    where.tags = { some: { tagId: { in: opts.tagIds } } };
+  }
+  if (opts?.search) {
+    const q = opts.search.trim();
+    if (q) {
+      where.AND = [
+        {
+          OR: [
+            { title: { contains: q, mode: "insensitive" } },
+            { description: { contains: q, mode: "insensitive" } },
+          ],
+        },
+      ];
+    }
+  }
+
+  const recipes = await prisma.recipe.findMany({
+    where,
+    select: {
+      id: true,
+      title: true,
+      slug: true,
+      description: true,
+      coverImageUrl: true,
+      prepMinutes: true,
+      cookMinutes: true,
+      servings: true,
+      difficulty: true,
+      cuisine: true,
+      mealType: true,
+      cookCount: true,
+      lastCookedAt: true,
+      rating: true,
+      ownerId: true,
+      ownerTeamId: true,
+      cookbookId: true,
+      isPublic: true,
+      isArchived: true,
+      createdAt: true,
+      updatedAt: true,
+      tags: { include: { tag: true } },
+    },
+    orderBy: [{ lastCookedAt: { sort: "desc", nulls: "last" } }, { updatedAt: "desc" }],
+  });
+
+  let filtered = recipes;
+  if (opts?.maxMinutes != null) {
+    const max = opts.maxMinutes;
+    filtered = filtered.filter((r) => (r.prepMinutes ?? 0) + (r.cookMinutes ?? 0) <= max);
+  }
+
+  return filtered as unknown as RecipeListItem[];
+}
+
+export async function getRecipe(slugOrId: string): Promise<RecipeFull | null> {
+  const user = await requireAuth();
+  const teamIds = await getUserTeamIds(user.id);
+
+  const recipe = await prisma.recipe.findFirst({
+    where: {
+      OR: [{ slug: slugOrId }, { id: slugOrId }],
+    },
+    include: {
+      ingredients: { include: { product: true }, orderBy: { order: "asc" } },
+      steps: { orderBy: { order: "asc" } },
+      images: { orderBy: { order: "asc" } },
+      tags: { include: { tag: true } },
+      cookbook: true,
+    },
+  });
+
+  if (!recipe) return null;
+
+  const hasAccess =
+    recipe.ownerId === user.id ||
+    (recipe.ownerTeamId && teamIds.includes(recipe.ownerTeamId)) ||
+    recipe.isPublic;
+  if (!hasAccess) return null;
+
+  return recipe as unknown as RecipeFull;
+}
+
+// ─── Create / update / delete ─────────────────────────────────────────────
+
+export async function createRecipe(data: CreateRecipeInput): Promise<Recipe> {
+  const user = await requireAuth();
+
+  if (data.ownerTeamId) {
+    const teamIds = await getUserTeamIds(user.id);
+    if (!teamIds.includes(data.ownerTeamId)) throw new Error("Nie jesteś członkiem tego teamu");
+  }
+
+  const title = data.title.trim();
+  if (!title) throw new Error("Tytuł przepisu jest wymagany");
+
+  const slug = await uniqueSlug(title);
+
+  const recipe = await prisma.recipe.create({
+    data: {
+      title,
+      slug,
+      description: data.description?.trim() || null,
+      servings: data.servings ?? 2,
+      prepMinutes: data.prepMinutes ?? null,
+      cookMinutes: data.cookMinutes ?? null,
+      difficulty: (data.difficulty as Difficulty | undefined) ?? "easy",
+      cuisine: data.cuisine?.trim() || null,
+      mealType: data.mealType ?? null,
+      coverImageUrl: data.coverImageUrl?.trim() || null,
+      notes: data.notes ?? "",
+      introMarkdown: data.introMarkdown ?? "",
+      cookbookId: data.cookbookId ?? null,
+      ownerId: data.ownerTeamId ? null : user.id,
+      ownerTeamId: data.ownerTeamId ?? null,
+      tags: data.tagIds?.length
+        ? { create: data.tagIds.map((tagId) => ({ tagId })) }
+        : undefined,
+      ingredients: data.ingredients?.length
+        ? {
+            create: data.ingredients.map((ing, idx) => ({
+              name: ing.name.trim(),
+              productId: ing.productId ?? null,
+              quantity: ing.quantity ?? null,
+              unit: ing.unit ?? null,
+              groupName: ing.groupName ?? null,
+              note: ing.note ?? null,
+              isOptional: ing.isOptional ?? false,
+              order: ing.order ?? idx,
+            })),
+          }
+        : undefined,
+      steps: data.steps?.length
+        ? {
+            create: data.steps.map((s, idx) => ({
+              text: s.text,
+              order: s.order ?? idx,
+              durationMin: s.durationMin ?? null,
+              temperature: s.temperature ?? null,
+              imageUrl: s.imageUrl ?? null,
+            })),
+          }
+        : undefined,
+    },
+  });
+
+  void trackActivity("kitchen", "create_recipe", { id: recipe.id, title });
+  revalidatePath("/kitchen/recipes");
+  return recipe;
+}
+
+export async function updateRecipe(id: string, data: UpdateRecipeInput): Promise<Recipe> {
+  const user = await requireAuth();
+  await assertRecipeAccess(id, user.id, "edit");
+
+  const patch: Record<string, unknown> = {};
+  if (data.title != null) {
+    patch.title = data.title.trim();
+    patch.slug = await uniqueSlug(patch.title as string, id);
+  }
+  if (data.description !== undefined) patch.description = data.description?.trim() || null;
+  if (data.servings != null) patch.servings = data.servings;
+  if (data.prepMinutes !== undefined) patch.prepMinutes = data.prepMinutes;
+  if (data.cookMinutes !== undefined) patch.cookMinutes = data.cookMinutes;
+  if (data.difficulty != null) patch.difficulty = data.difficulty;
+  if (data.cuisine !== undefined) patch.cuisine = data.cuisine?.trim() || null;
+  if (data.mealType !== undefined) patch.mealType = data.mealType;
+  if (data.coverImageUrl !== undefined) patch.coverImageUrl = data.coverImageUrl?.trim() || null;
+  if (data.notes !== undefined) patch.notes = data.notes ?? "";
+  if (data.introMarkdown !== undefined) patch.introMarkdown = data.introMarkdown ?? "";
+  if (data.cookbookId !== undefined) patch.cookbookId = data.cookbookId;
+
+  const recipe = await prisma.recipe.update({ where: { id }, data: patch });
+
+  if (data.tagIds) {
+    await prisma.recipeTag.deleteMany({ where: { recipeId: id } });
+    if (data.tagIds.length > 0) {
+      await prisma.recipeTag.createMany({
+        data: data.tagIds.map((tagId) => ({ recipeId: id, tagId })),
+      });
+    }
+  }
+
+  revalidatePath("/kitchen/recipes");
+  revalidatePath(`/kitchen/recipes/${recipe.slug}`);
+  return recipe;
+}
+
+export async function deleteRecipe(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertRecipeAccess(id, user.id, "edit");
+  await prisma.recipe.delete({ where: { id } });
+  revalidatePath("/kitchen/recipes");
+}
+
+export async function archiveRecipe(id: string): Promise<void> {
+  const user = await requireAuth();
+  await assertRecipeAccess(id, user.id, "edit");
+  await prisma.recipe.update({ where: { id }, data: { isArchived: true } });
+  revalidatePath("/kitchen/recipes");
+}
+
+export async function duplicateRecipe(id: string): Promise<Recipe> {
+  const user = await requireAuth();
+  await assertRecipeAccess(id, user.id, "read");
+
+  const src = await prisma.recipe.findUnique({
+    where: { id },
+    include: { ingredients: true, steps: true, tags: true },
+  });
+  if (!src) throw new Error("Przepis nie istnieje");
+
+  const title = `${src.title} (kopia)`;
+  const slug = await uniqueSlug(title);
+
+  const copy = await prisma.recipe.create({
+    data: {
+      title,
+      slug,
+      description: src.description,
+      introMarkdown: src.introMarkdown,
+      notes: src.notes,
+      servings: src.servings,
+      prepMinutes: src.prepMinutes,
+      cookMinutes: src.cookMinutes,
+      difficulty: src.difficulty,
+      cuisine: src.cuisine,
+      mealType: src.mealType,
+      coverImageUrl: src.coverImageUrl,
+      cookbookId: src.cookbookId,
+      ownerId: user.id,
+      ownerTeamId: null,
+      sourceType: "manual",
+      tags: { create: src.tags.map((t) => ({ tagId: t.tagId })) },
+      ingredients: {
+        create: src.ingredients.map((ing) => ({
+          name: ing.name,
+          productId: ing.productId,
+          quantity: ing.quantity,
+          unit: ing.unit,
+          groupName: ing.groupName,
+          note: ing.note,
+          isOptional: ing.isOptional,
+          order: ing.order,
+        })),
+      },
+      steps: {
+        create: src.steps.map((s) => ({
+          text: s.text,
+          order: s.order,
+          durationMin: s.durationMin,
+          temperature: s.temperature,
+          imageUrl: s.imageUrl,
+        })),
+      },
+    },
+  });
+
+  revalidatePath("/kitchen/recipes");
+  return copy;
+}
+
+// ─── Ingredients ──────────────────────────────────────────────────────────
+
+export async function addIngredient(recipeId: string, data: IngredientInput): Promise<RecipeIngredient> {
+  const user = await requireAuth();
+  await assertRecipeAccess(recipeId, user.id, "edit");
+
+  const last = await prisma.recipeIngredient.findFirst({
+    where: { recipeId, groupName: data.groupName ?? null },
+    orderBy: { order: "desc" },
+    select: { order: true },
+  });
+  const order = data.order ?? (last ? last.order + 1 : 0);
+
+  const ing = await prisma.recipeIngredient.create({
+    data: {
+      recipeId,
+      name: data.name.trim(),
+      productId: data.productId ?? null,
+      quantity: data.quantity ?? null,
+      unit: data.unit ?? null,
+      groupName: data.groupName ?? null,
+      note: data.note ?? null,
+      isOptional: data.isOptional ?? false,
+      order,
+    },
+  });
+
+  revalidatePath(`/kitchen/recipes`);
+  return ing;
+}
+
+export async function updateIngredient(id: string, data: IngredientInput): Promise<RecipeIngredient> {
+  const user = await requireAuth();
+  const existing = await prisma.recipeIngredient.findUnique({ where: { id }, select: { recipeId: true } });
+  if (!existing) throw new Error("Składnik nie istnieje");
+  await assertRecipeAccess(existing.recipeId, user.id, "edit");
+
+  const ing = await prisma.recipeIngredient.update({
+    where: { id },
+    data: {
+      name: data.name.trim(),
+      productId: data.productId ?? null,
+      quantity: data.quantity ?? null,
+      unit: data.unit ?? null,
+      groupName: data.groupName ?? null,
+      note: data.note ?? null,
+      isOptional: data.isOptional ?? false,
+      ...(data.order != null ? { order: data.order } : {}),
+    },
+  });
+
+  revalidatePath(`/kitchen/recipes`);
+  return ing;
+}
+
+export async function deleteIngredient(id: string): Promise<void> {
+  const user = await requireAuth();
+  const existing = await prisma.recipeIngredient.findUnique({ where: { id }, select: { recipeId: true } });
+  if (!existing) return;
+  await assertRecipeAccess(existing.recipeId, user.id, "edit");
+  await prisma.recipeIngredient.delete({ where: { id } });
+  revalidatePath(`/kitchen/recipes`);
+}
+
+export async function reorderIngredients(recipeId: string, orderedIds: string[]): Promise<void> {
+  const user = await requireAuth();
+  await assertRecipeAccess(recipeId, user.id, "edit");
+  await prisma.$transaction(
+    orderedIds.map((id, idx) =>
+      prisma.recipeIngredient.update({ where: { id }, data: { order: idx } })
+    )
+  );
+  revalidatePath(`/kitchen/recipes`);
+}
+
+// ─── Steps ────────────────────────────────────────────────────────────────
+
+export async function addStep(recipeId: string, data: StepInput): Promise<RecipeStep> {
+  const user = await requireAuth();
+  await assertRecipeAccess(recipeId, user.id, "edit");
+
+  const last = await prisma.recipeStep.findFirst({
+    where: { recipeId },
+    orderBy: { order: "desc" },
+    select: { order: true },
+  });
+  const order = data.order ?? (last ? last.order + 1 : 0);
+
+  const step = await prisma.recipeStep.create({
+    data: {
+      recipeId,
+      text: data.text,
+      order,
+      durationMin: data.durationMin ?? null,
+      temperature: data.temperature ?? null,
+      imageUrl: data.imageUrl ?? null,
+    },
+  });
+
+  revalidatePath(`/kitchen/recipes`);
+  return step;
+}
+
+export async function updateStep(id: string, data: StepInput): Promise<RecipeStep> {
+  const user = await requireAuth();
+  const existing = await prisma.recipeStep.findUnique({ where: { id }, select: { recipeId: true } });
+  if (!existing) throw new Error("Krok nie istnieje");
+  await assertRecipeAccess(existing.recipeId, user.id, "edit");
+
+  const step = await prisma.recipeStep.update({
+    where: { id },
+    data: {
+      text: data.text,
+      ...(data.order != null ? { order: data.order } : {}),
+      durationMin: data.durationMin ?? null,
+      temperature: data.temperature ?? null,
+      imageUrl: data.imageUrl ?? null,
+    },
+  });
+
+  revalidatePath(`/kitchen/recipes`);
+  return step;
+}
+
+export async function deleteStep(id: string): Promise<void> {
+  const user = await requireAuth();
+  const existing = await prisma.recipeStep.findUnique({ where: { id }, select: { recipeId: true } });
+  if (!existing) return;
+  await assertRecipeAccess(existing.recipeId, user.id, "edit");
+  await prisma.recipeStep.delete({ where: { id } });
+  revalidatePath(`/kitchen/recipes`);
+}
+
+export async function reorderSteps(recipeId: string, orderedIds: string[]): Promise<void> {
+  const user = await requireAuth();
+  await assertRecipeAccess(recipeId, user.id, "edit");
+  await prisma.$transaction(
+    orderedIds.map((id, idx) =>
+      prisma.recipeStep.update({ where: { id }, data: { order: idx } })
+    )
+  );
+  revalidatePath(`/kitchen/recipes`);
+}
+
+// ─── Shop for recipe ──────────────────────────────────────────────────────
+
+export interface ShopForRecipeInput {
+  recipeId: string;
+  listId: string;
+  servings: number;
+  skipPantry?: boolean;
+  skipOptional?: boolean;
+  ingredientOverrides?: Array<{ ingredientId: string; include: boolean; quantity?: number }>;
+}
+
+export interface ShopForRecipeResult {
+  addedItems: Item[];
+  skippedFromPantry: Array<{ name: string; quantity: number | null }>;
+  skippedOptional: number;
+}
+
+export async function shopForRecipe(input: ShopForRecipeInput): Promise<ShopForRecipeResult> {
+  const user = await requireAuth();
+  await assertRecipeAccess(input.recipeId, user.id, "read");
+  await assertListAccess(input.listId, user.id);
+
+  const recipe = await prisma.recipe.findUnique({
+    where: { id: input.recipeId },
+    include: { ingredients: { include: { product: true } } },
+  });
+  if (!recipe) throw new Error("Przepis nie istnieje");
+
+  const scale = recipe.servings > 0 ? input.servings / recipe.servings : 1;
+  const overrides = new Map(
+    (input.ingredientOverrides ?? []).map((o) => [o.ingredientId, o])
+  );
+
+  const teamIds = await getUserTeamIds(user.id);
+  const pantry = input.skipPantry
+    ? await prisma.pantryItem.findMany({
+        where: {
+          OR: [
+            { ownerId: user.id },
+            ...(teamIds.length > 0 ? [{ ownerTeamId: { in: teamIds } }] : []),
+          ],
+        },
+      })
+    : [];
+
+  function pantryHas(name: string, productId: string | null): boolean {
+    return pantry.some((p) => {
+      if (productId && p.productId === productId) return (p.quantity ?? 0) > 0;
+      return p.name.toLowerCase() === name.toLowerCase() && (p.quantity ?? 0) > 0;
+    });
+  }
+
+  const added: Item[] = [];
+  const skippedFromPantry: Array<{ name: string; quantity: number | null }> = [];
+  let skippedOptional = 0;
+
+  for (const ing of recipe.ingredients) {
+    const ov = overrides.get(ing.id);
+    if (ov && ov.include === false) continue;
+
+    if (ing.isOptional && input.skipOptional) {
+      skippedOptional += 1;
+      continue;
+    }
+
+    const baseName = ing.product?.name ?? ing.name;
+    if (input.skipPantry && pantryHas(baseName, ing.productId)) {
+      skippedFromPantry.push({
+        name: baseName,
+        quantity: ing.quantity != null ? ing.quantity * scale : null,
+      });
+      continue;
+    }
+
+    const scaledQuantity =
+      ov?.quantity != null
+        ? ov.quantity
+        : ing.quantity != null
+        ? Math.round(ing.quantity * scale * 100) / 100
+        : null;
+
+    const unit = ing.unit ?? ing.product?.defaultUnit ?? null;
+    const category = ing.product?.category ?? categorize(baseName);
+
+    const item = await prisma.item.create({
+      data: {
+        listId: input.listId,
+        name: baseName,
+        quantity: scaledQuantity,
+        unit,
+        category,
+        recipeOrigin: {
+          create: {
+            recipeId: recipe.id,
+            servings: input.servings,
+            ingredientId: ing.id,
+          },
+        },
+      },
+    });
+    added.push(item);
+  }
+
+  void trackActivity("kitchen", "shop_for_recipe", {
+    recipeId: recipe.id,
+    listId: input.listId,
+    addedCount: added.length,
+    servings: input.servings,
+  });
+
+  revalidatePath(`/shopping/${input.listId}`);
+  revalidatePath("/kitchen/recipes");
+  return { addedItems: added, skippedFromPantry, skippedOptional };
+}
+
+// ─── Cook tracking ────────────────────────────────────────────────────────
+
+export async function markRecipeCooked(id: string, servings: number): Promise<void> {
+  const user = await requireAuth();
+  await assertRecipeAccess(id, user.id, "read");
+
+  await prisma.recipe.update({
+    where: { id },
+    data: {
+      cookCount: { increment: 1 },
+      lastCookedAt: new Date(),
+    },
+  });
+
+  void trackActivity("kitchen", "mark_cooked", { recipeId: id, servings });
+  revalidatePath("/kitchen/recipes");
+  revalidatePath(`/kitchen/recipes/${id}`);
+}

--- a/worldofmag/src/app/api/llm/kitchen/import-url/route.ts
+++ b/worldofmag/src/app/api/llm/kitchen/import-url/route.ts
@@ -1,0 +1,256 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+interface ParsedRecipe {
+  title: string;
+  description?: string | null;
+  servings?: number | null;
+  prepMinutes?: number | null;
+  cookMinutes?: number | null;
+  cuisine?: string | null;
+  mealType?: string | null;
+  coverImageUrl?: string | null;
+  notes?: string | null;
+  ingredients: Array<{
+    name: string;
+    quantity: number | null;
+    unit: string | null;
+    note: string | null;
+    isOptional: boolean;
+  }>;
+  steps: Array<{ text: string }>;
+}
+
+function parseIsoDuration(d: string): number | null {
+  if (!d) return null;
+  const m = /^PT(?:(\d+)H)?(?:(\d+)M)?$/.exec(d);
+  if (!m) return null;
+  return (Number(m[1] ?? 0)) * 60 + Number(m[2] ?? 0);
+}
+
+function parseIngredientString(raw: string): {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+} {
+  const trimmed = raw.trim();
+  const m = /^([\d,./\s]+)?\s*([a-zA-Ząęóćłńżźś]{1,8})?\s+(.+)$/i.exec(trimmed);
+  if (!m) return { name: trimmed, quantity: null, unit: null };
+  const qtyStr = m[1]?.replace(",", ".").replace(/\//g, " ").trim();
+  let qty: number | null = null;
+  if (qtyStr) {
+    const parts = qtyStr.split(/\s+/).map(Number).filter((n) => !Number.isNaN(n));
+    if (parts.length === 1) qty = parts[0];
+    else if (parts.length === 2) qty = parts[0] + parts[1] / 10;
+  }
+  const unit = m[2] && /^(g|kg|dkg|ml|l|szt|op|łyżka|łyżeczka|szklanka|szklanki)$/i.test(m[2]) ? m[2] : null;
+  const name = (m[3] ?? trimmed).replace(/^[-,:]\s*/, "").trim();
+  return { name, quantity: qty, unit };
+}
+
+function pickFirst<T>(...values: T[]): T | undefined {
+  for (const v of values) if (v != null) return v;
+  return undefined;
+}
+
+function extractFromJsonLd(html: string): ParsedRecipe | null {
+  const matches = Array.from(
+    html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+  );
+  for (const m of matches) {
+    try {
+      const json = JSON.parse(m[1]);
+      const list: unknown[] = Array.isArray(json) ? json : json["@graph"] ?? [json];
+      for (const node of list) {
+        if (!node || typeof node !== "object") continue;
+        const n = node as Record<string, unknown>;
+        const t = n["@type"];
+        const isRecipe =
+          t === "Recipe" || (Array.isArray(t) && (t as string[]).includes("Recipe"));
+        if (!isRecipe) continue;
+
+        const ingredientsRaw = (n.recipeIngredient as unknown) ?? [];
+        const ingredients = Array.isArray(ingredientsRaw)
+          ? (ingredientsRaw as unknown[]).map((s) => {
+              const parsed = parseIngredientString(String(s));
+              return { ...parsed, note: null, isOptional: false };
+            })
+          : [];
+
+        const instructionsRaw = (n.recipeInstructions as unknown) ?? [];
+        const steps: Array<{ text: string }> = [];
+        if (Array.isArray(instructionsRaw)) {
+          for (const s of instructionsRaw as unknown[]) {
+            if (typeof s === "string") steps.push({ text: s });
+            else if (s && typeof s === "object") {
+              const obj = s as Record<string, unknown>;
+              if (obj["@type"] === "HowToStep" && typeof obj.text === "string") {
+                steps.push({ text: obj.text });
+              } else if (obj["@type"] === "HowToSection" && Array.isArray(obj.itemListElement)) {
+                for (const inner of obj.itemListElement as unknown[]) {
+                  if (inner && typeof inner === "object" && typeof (inner as Record<string, unknown>).text === "string") {
+                    steps.push({ text: String((inner as Record<string, unknown>).text) });
+                  }
+                }
+              } else if (typeof obj.text === "string") {
+                steps.push({ text: obj.text });
+              }
+            }
+          }
+        } else if (typeof instructionsRaw === "string") {
+          steps.push({ text: instructionsRaw });
+        }
+
+        const imageRaw = n.image as unknown;
+        let coverImageUrl: string | null = null;
+        if (typeof imageRaw === "string") coverImageUrl = imageRaw;
+        else if (Array.isArray(imageRaw) && typeof imageRaw[0] === "string") coverImageUrl = imageRaw[0] as string;
+        else if (imageRaw && typeof imageRaw === "object") {
+          const url = (imageRaw as Record<string, unknown>).url;
+          if (typeof url === "string") coverImageUrl = url;
+        }
+
+        const yieldRaw = pickFirst(n.recipeYield, n.yield);
+        let servings: number | null = null;
+        if (typeof yieldRaw === "string") {
+          const m = /(\d+)/.exec(yieldRaw);
+          if (m) servings = Number(m[1]);
+        } else if (typeof yieldRaw === "number") {
+          servings = yieldRaw;
+        }
+
+        return {
+          title: String(n.name ?? "Bez nazwy"),
+          description: typeof n.description === "string" ? n.description : null,
+          servings,
+          prepMinutes: typeof n.prepTime === "string" ? parseIsoDuration(n.prepTime) : null,
+          cookMinutes: typeof n.cookTime === "string" ? parseIsoDuration(n.cookTime) : null,
+          cuisine: typeof n.recipeCuisine === "string" ? n.recipeCuisine : null,
+          mealType: typeof n.recipeCategory === "string" ? n.recipeCategory.toLowerCase() : null,
+          coverImageUrl,
+          notes: null,
+          ingredients,
+          steps,
+        };
+      }
+    } catch {
+      // continue scanning
+    }
+  }
+  return null;
+}
+
+async function extractWithLLM(html: string, sourceUrl: string): Promise<ParsedRecipe | null> {
+  const config = await prisma.config.findUnique({ where: { key: "groq_api_key" } });
+  if (!config?.value) return null;
+
+  // Strip tags to keep token budget lean
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 12000);
+
+  const SYSTEM = `Jesteś parserem przepisów kulinarnych. Otrzymasz tekst strony WWW. Wyciągnij przepis i zwróć WYŁĄCZNIE JSON w schemacie:
+{
+  "title": string,
+  "description": string|null,
+  "servings": number|null,
+  "prepMinutes": number|null,
+  "cookMinutes": number|null,
+  "cuisine": string|null,
+  "mealType": "breakfast"|"lunch"|"dinner"|"snack"|"dessert"|null,
+  "ingredients": [{"name":string,"quantity":number|null,"unit":string|null,"note":string|null,"isOptional":boolean}],
+  "steps": [{"text":string}]
+}
+Nazwy składników i kroki po polsku. Jeśli tekst nie wygląda jak przepis, zwróć {"error":"not-a-recipe"}.`;
+
+  const groqRes = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.value}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.1-8b-instant",
+      messages: [
+        { role: "system", content: SYSTEM },
+        { role: "user", content: `URL: ${sourceUrl}\n\nText:\n${text}` },
+      ],
+      temperature: 0.1,
+      max_tokens: 3000,
+    }),
+  });
+
+  if (!groqRes.ok) return null;
+  const data = await groqRes.json();
+  const content: string = data.choices?.[0]?.message?.content ?? "{}";
+  try {
+    const cleaned = content.trim().replace(/^```(?:json)?\s*/i, "").replace(/```$/, "");
+    const parsed = JSON.parse(cleaned);
+    if (parsed.error) return null;
+    return {
+      title: String(parsed.title ?? "Bez nazwy"),
+      description: parsed.description ?? null,
+      servings: parsed.servings ?? null,
+      prepMinutes: parsed.prepMinutes ?? null,
+      cookMinutes: parsed.cookMinutes ?? null,
+      cuisine: parsed.cuisine ?? null,
+      mealType: parsed.mealType ?? null,
+      coverImageUrl: null,
+      notes: null,
+      ingredients: Array.isArray(parsed.ingredients) ? parsed.ingredients : [],
+      steps: Array.isArray(parsed.steps) ? parsed.steps : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { url } = await req.json().catch(() => ({ url: "" }));
+  if (!url || typeof url !== "string") {
+    return NextResponse.json({ error: "URL wymagany" }, { status: 400 });
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+    if (!["http:", "https:"].includes(parsed.protocol)) throw new Error("bad-proto");
+  } catch {
+    return NextResponse.json({ error: "Nieprawidłowy URL" }, { status: 400 });
+  }
+
+  let html: string;
+  try {
+    const res = await fetch(parsed.toString(), {
+      headers: { "User-Agent": "Mozilla/5.0 (WorldOfMag Recipe Importer)" },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    html = await res.text();
+  } catch (e) {
+    return NextResponse.json(
+      { error: `Nie udało się pobrać strony: ${e instanceof Error ? e.message : "błąd"}` },
+      { status: 502 }
+    );
+  }
+
+  let recipe = extractFromJsonLd(html);
+  if (!recipe || recipe.ingredients.length === 0) {
+    recipe = await extractWithLLM(html, parsed.toString());
+  }
+  if (!recipe) {
+    return NextResponse.json(
+      { error: "Nie udało się rozpoznać przepisu. Spróbuj inny URL lub wpisz ręcznie." },
+      { status: 422 }
+    );
+  }
+
+  return NextResponse.json({ recipe, sourceUrl: parsed.toString() });
+}

--- a/worldofmag/src/app/api/llm/kitchen/parse-ingredients/route.ts
+++ b/worldofmag/src/app/api/llm/kitchen/parse-ingredients/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const SYSTEM_PROMPT = `Jesteś parserem składników kulinarnych po polsku.
+Otrzymasz blok tekstu z listą składników (jeden na linię lub po przecinkach).
+Zwróć TYLKO tablicę JSON, bez żadnego komentarza.
+
+Schema:
+[{
+  "name": string,           // krótka nazwa składnika małymi literami, bez ilości (np. "mąka pszenna")
+  "quantity": number|null,  // wartość liczbowa
+  "unit": string|null,      // jednostka: kg, dkg, g, l, ml, szt, łyżka, łyżeczka, szczypta, op, paczka, butelka, puszka, torebka, słoik
+  "note": string|null,      // np. "drobno posiekane", "schłodzone"
+  "isOptional": boolean     // true gdy w tekście jest "opcjonalnie" lub "do smaku"
+}]
+
+Przykład wejścia:
+400 g spaghetti
+200g boczku
+4 żółtka
+100g parmezanu
+szczypta soli (do smaku)
+pietruszka — opcjonalnie
+
+Przykład wyjścia:
+[
+  {"name":"spaghetti","quantity":400,"unit":"g","note":null,"isOptional":false},
+  {"name":"boczek","quantity":200,"unit":"g","note":null,"isOptional":false},
+  {"name":"żółtko","quantity":4,"unit":"szt","note":null,"isOptional":false},
+  {"name":"parmezan","quantity":100,"unit":"g","note":null,"isOptional":false},
+  {"name":"sól","quantity":null,"unit":"szczypta","note":"do smaku","isOptional":true},
+  {"name":"pietruszka","quantity":null,"unit":null,"note":null,"isOptional":true}
+]`;
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { text } = await req.json().catch(() => ({ text: "" }));
+  if (!text?.trim()) {
+    return NextResponse.json({ error: "Empty text" }, { status: 400 });
+  }
+
+  const config = await prisma.config.findUnique({ where: { key: "groq_api_key" } });
+  if (!config?.value) {
+    return NextResponse.json(
+      { error: "LLM nie jest skonfigurowany. Ustaw klucz Groq w panelu admina." },
+      { status: 503 }
+    );
+  }
+
+  const groqRes = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.value}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.1-8b-instant",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: String(text).slice(0, 4000) },
+      ],
+      temperature: 0.1,
+      max_tokens: 2048,
+    }),
+  });
+
+  if (!groqRes.ok) {
+    const err = await groqRes.text().catch(() => "unknown");
+    return NextResponse.json({ error: `Groq error: ${err}` }, { status: 502 });
+  }
+
+  const data = await groqRes.json();
+  const content: string = data.choices?.[0]?.message?.content ?? "[]";
+
+  let ingredients: Array<{
+    name: string;
+    quantity: number | null;
+    unit: string | null;
+    note: string | null;
+    isOptional: boolean;
+  }>;
+  try {
+    const cleaned = content.trim().replace(/^```(?:json)?\s*/i, "").replace(/```$/, "");
+    ingredients = JSON.parse(cleaned);
+    if (!Array.isArray(ingredients)) throw new Error("not array");
+  } catch {
+    return NextResponse.json({ error: "LLM zwrócił nieprawidłowy format" }, { status: 502 });
+  }
+
+  return NextResponse.json({ ingredients });
+}

--- a/worldofmag/src/app/api/llm/kitchen/suggest-from-pantry/route.ts
+++ b/worldofmag/src/app/api/llm/kitchen/suggest-from-pantry/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getPantry } from "@/actions/pantry";
+import { getRecipes } from "@/actions/recipes";
+
+interface Suggestion {
+  recipeId: string;
+  slug: string;
+  title: string;
+  reason: string;
+  matchedIngredients: string[];
+}
+
+export async function POST(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [pantry, recipes] = await Promise.all([getPantry(), getRecipes()]);
+  if (pantry.length === 0 || recipes.length === 0) {
+    return NextResponse.json({ suggestions: [] });
+  }
+
+  const pantryNames = pantry
+    .filter((p) => (p.quantity ?? 0) > 0)
+    .map((p) => (p.product?.name ?? p.name).toLowerCase());
+
+  // Quick rule-based pre-filter — find recipes with highest overlap of ingredients with pantry.
+  const fullRecipes = await prisma.recipe.findMany({
+    where: { id: { in: recipes.slice(0, 50).map((r) => r.id) } },
+    include: { ingredients: { include: { product: true } } },
+  });
+
+  type Scored = { recipe: typeof fullRecipes[number]; matched: string[]; score: number };
+  const scored: Scored[] = fullRecipes.map((r) => {
+    const ingNames = r.ingredients.map((i) => (i.product?.name ?? i.name).toLowerCase());
+    const matched = ingNames.filter((n) => pantryNames.some((p) => n.includes(p) || p.includes(n)));
+    const score = r.ingredients.length > 0 ? matched.length / r.ingredients.length : 0;
+    return { recipe: r, matched, score };
+  });
+
+  const top = scored
+    .filter((s) => s.matched.length > 0)
+    .sort((a, b) => b.score - a.score || b.matched.length - a.matched.length)
+    .slice(0, 5);
+
+  const suggestions: Suggestion[] = top.map((s) => ({
+    recipeId: s.recipe.id,
+    slug: s.recipe.slug,
+    title: s.recipe.title,
+    reason: `Masz ${s.matched.length} z ${s.recipe.ingredients.length} składników`,
+    matchedIngredients: s.matched.slice(0, 5),
+  }));
+
+  return NextResponse.json({ suggestions });
+}

--- a/worldofmag/src/app/globals.css
+++ b/worldofmag/src/app/globals.css
@@ -21,6 +21,11 @@
   --accent-amber:   #f59e0b;
   --accent-amber-dim: #b45309;
   --accent-purple:  #a855f7;
+  --accent-orange:  #ff8a3d;
+  --accent-orange-dim: #c2410c;
+  --kitchen-pantry:    #4caf50;
+  --kitchen-expiring:  #ff9800;
+  --kitchen-expired:   #f44336;
   --sidebar-width:  220px;
 }
 

--- a/worldofmag/src/app/kitchen/cookbooks/page.tsx
+++ b/worldofmag/src/app/kitchen/cookbooks/page.tsx
@@ -1,0 +1,17 @@
+import { BookOpen } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default function KitchenCookbooksPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+      <BookOpen size={48} style={{ color: "var(--text-muted)" }} />
+      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Książki kucharskie
+      </h2>
+      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+        Wkrótce — Faza 1. Grupowanie przepisów w kolekcje.
+      </p>
+    </div>
+  );
+}

--- a/worldofmag/src/app/kitchen/layout.tsx
+++ b/worldofmag/src/app/kitchen/layout.tsx
@@ -1,0 +1,5 @@
+import { KitchenLayout } from "@/components/kitchen/KitchenLayout";
+
+export default function KitchenAppLayout({ children }: { children: React.ReactNode }) {
+  return <KitchenLayout>{children}</KitchenLayout>;
+}

--- a/worldofmag/src/app/kitchen/page.tsx
+++ b/worldofmag/src/app/kitchen/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function KitchenIndexPage() {
+  redirect("/kitchen/recipes");
+}

--- a/worldofmag/src/app/kitchen/pantry/page.tsx
+++ b/worldofmag/src/app/kitchen/pantry/page.tsx
@@ -1,17 +1,15 @@
-import { Package } from "lucide-react";
-
 export const dynamic = "force-dynamic";
 
-export default function KitchenPantryPage() {
-  return (
-    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
-      <Package size={48} style={{ color: "var(--text-muted)" }} />
-      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
-        Spiżarnia
-      </h2>
-      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
-        Wkrótce — Faza 3. Stan magazynu, terminy ważności, auto-uzupełnianie.
-      </p>
-    </div>
-  );
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getPantry, getExpiringSoon } from "@/actions/pantry";
+import { PantryList } from "@/components/kitchen/pantry/PantryList";
+
+export default async function KitchenPantryPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const [items, expiring] = await Promise.all([getPantry(), getExpiringSoon(3)]);
+
+  return <PantryList items={items} expiringSoon={expiring} />;
 }

--- a/worldofmag/src/app/kitchen/pantry/page.tsx
+++ b/worldofmag/src/app/kitchen/pantry/page.tsx
@@ -1,0 +1,17 @@
+import { Package } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default function KitchenPantryPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+      <Package size={48} style={{ color: "var(--text-muted)" }} />
+      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Spiżarnia
+      </h2>
+      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+        Wkrótce — Faza 3. Stan magazynu, terminy ważności, auto-uzupełnianie.
+      </p>
+    </div>
+  );
+}

--- a/worldofmag/src/app/kitchen/pantry/stocktake/page.tsx
+++ b/worldofmag/src/app/kitchen/pantry/stocktake/page.tsx
@@ -1,0 +1,14 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getPantry } from "@/actions/pantry";
+import { StockTakeMode } from "@/components/kitchen/pantry/StockTakeMode";
+
+export default async function StocktakePage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const items = await getPantry();
+  return <StockTakeMode items={items} />;
+}

--- a/worldofmag/src/app/kitchen/plan/page.tsx
+++ b/worldofmag/src/app/kitchen/plan/page.tsx
@@ -1,0 +1,17 @@
+import { CalendarDays } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default function KitchenPlanPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+      <CalendarDays size={48} style={{ color: "var(--text-muted)" }} />
+      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Plan posiłków
+      </h2>
+      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+        Wkrótce — Faza 2. Tygodniowy plan, drag-and-drop, generowanie listy zakupów na cały tydzień.
+      </p>
+    </div>
+  );
+}

--- a/worldofmag/src/app/kitchen/plan/page.tsx
+++ b/worldofmag/src/app/kitchen/plan/page.tsx
@@ -1,17 +1,48 @@
-import { CalendarDays } from "lucide-react";
-
 export const dynamic = "force-dynamic";
 
-export default function KitchenPlanPage() {
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getMealPlan } from "@/actions/mealPlans";
+import { getRecipes } from "@/actions/recipes";
+import { getLists } from "@/actions/lists";
+import { getWeekStart, getWeekEnd, dateKey } from "@/lib/kitchenDate";
+import { MealPlanWeek } from "@/components/kitchen/plan/MealPlanWeek";
+
+interface PageProps {
+  searchParams: { week?: string };
+}
+
+export default async function KitchenPlanPage({ searchParams }: PageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const anchor = searchParams.week ? new Date(`${searchParams.week}T12:00:00`) : new Date();
+  const from = getWeekStart(anchor);
+  const to = getWeekEnd(anchor);
+
+  const [entries, recipes, lists] = await Promise.all([
+    getMealPlan({ from, to }),
+    getRecipes(),
+    getLists(),
+  ]);
+
   return (
-    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
-      <CalendarDays size={48} style={{ color: "var(--text-muted)" }} />
-      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
-        Plan posiłków
-      </h2>
-      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
-        Wkrótce — Faza 2. Tygodniowy plan, drag-and-drop, generowanie listy zakupów na cały tydzień.
-      </p>
-    </div>
+    <MealPlanWeek
+      initialWeek={dateKey(anchor)}
+      entries={entries.map((e) => ({
+        ...e,
+        date: new Date(e.date),
+        cookedAt: e.cookedAt ? new Date(e.cookedAt) : null,
+        createdAt: new Date(e.createdAt),
+        updatedAt: new Date(e.updatedAt),
+      }))}
+      recipes={recipes.map((r) => ({
+        id: r.id,
+        title: r.title,
+        slug: r.slug,
+        servings: r.servings,
+      }))}
+      lists={lists.map((l) => ({ id: l.id, name: l.name }))}
+    />
   );
 }

--- a/worldofmag/src/app/kitchen/recipes/[recipeId]/cook/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/[recipeId]/cook/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic";
+
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getRecipe } from "@/actions/recipes";
+import { CookMode } from "@/components/kitchen/recipes/CookMode";
+
+interface PageProps {
+  params: { recipeId: string };
+}
+
+export default async function CookModePage({ params }: PageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const recipe = await getRecipe(decodeURIComponent(params.recipeId));
+  if (!recipe) notFound();
+
+  return <CookMode recipe={recipe} />;
+}

--- a/worldofmag/src/app/kitchen/recipes/[recipeId]/edit/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/[recipeId]/edit/page.tsx
@@ -1,0 +1,29 @@
+export const dynamic = "force-dynamic";
+
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getRecipe, assertRecipeAccess } from "@/actions/recipes";
+import { getCookbooks } from "@/actions/cookbooks";
+import { RecipeEditor } from "@/components/kitchen/recipes/RecipeEditor";
+
+interface PageProps {
+  params: { recipeId: string };
+}
+
+export default async function EditRecipePage({ params }: PageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const recipe = await getRecipe(decodeURIComponent(params.recipeId));
+  if (!recipe) notFound();
+  await assertRecipeAccess(recipe.id, session.user.id, "edit");
+
+  const cookbooks = await getCookbooks();
+
+  return (
+    <RecipeEditor
+      recipe={recipe}
+      cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+    />
+  );
+}

--- a/worldofmag/src/app/kitchen/recipes/[recipeId]/edit/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/[recipeId]/edit/page.tsx
@@ -19,11 +19,13 @@ export default async function EditRecipePage({ params }: PageProps) {
   await assertRecipeAccess(recipe.id, session.user.id, "edit");
 
   const cookbooks = await getCookbooks();
+  const hasAI = session.user.permissions?.includes("kitchen.ai") ?? false;
 
   return (
     <RecipeEditor
       recipe={recipe}
       cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+      hasAI={hasAI}
     />
   );
 }

--- a/worldofmag/src/app/kitchen/recipes/[recipeId]/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/[recipeId]/page.tsx
@@ -1,0 +1,35 @@
+export const dynamic = "force-dynamic";
+
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getRecipe } from "@/actions/recipes";
+import { getLists } from "@/actions/lists";
+import { getUserTeamIds } from "@/lib/server-utils";
+import { RecipeView } from "@/components/kitchen/recipes/RecipeView";
+
+interface PageProps {
+  params: { recipeId: string };
+}
+
+export default async function RecipeDetailPage({ params }: PageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const recipe = await getRecipe(decodeURIComponent(params.recipeId));
+  if (!recipe) notFound();
+
+  const teamIds = await getUserTeamIds(session.user.id);
+  const canEdit =
+    recipe.ownerId === session.user.id ||
+    (recipe.ownerTeamId != null && teamIds.includes(recipe.ownerTeamId));
+
+  const lists = await getLists();
+
+  return (
+    <RecipeView
+      recipe={recipe}
+      lists={lists.map((l) => ({ id: l.id, name: l.name }))}
+      canEdit={canEdit}
+    />
+  );
+}

--- a/worldofmag/src/app/kitchen/recipes/new/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/new/page.tsx
@@ -1,0 +1,19 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getCookbooks } from "@/actions/cookbooks";
+import { RecipeEditor } from "@/components/kitchen/recipes/RecipeEditor";
+
+export default async function NewRecipePage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const cookbooks = await getCookbooks();
+
+  return (
+    <RecipeEditor
+      cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+    />
+  );
+}

--- a/worldofmag/src/app/kitchen/recipes/new/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/new/page.tsx
@@ -10,10 +10,12 @@ export default async function NewRecipePage() {
   if (!session?.user?.id) redirect("/auth/signin");
 
   const cookbooks = await getCookbooks();
+  const hasAI = session.user.permissions?.includes("kitchen.ai") ?? false;
 
   return (
     <RecipeEditor
       cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+      hasAI={hasAI}
     />
   );
 }

--- a/worldofmag/src/app/kitchen/recipes/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/page.tsx
@@ -1,17 +1,27 @@
-import { BookMarked } from "lucide-react";
-
 export const dynamic = "force-dynamic";
 
-export default function KitchenRecipesPage() {
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getRecipes } from "@/actions/recipes";
+import { getCookbooks } from "@/actions/cookbooks";
+import { getTags } from "@/actions/tags";
+import { RecipeList } from "@/components/kitchen/recipes/RecipeList";
+
+export default async function KitchenRecipesPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/signin");
+
+  const [recipes, cookbooks, tags] = await Promise.all([
+    getRecipes(),
+    getCookbooks(),
+    getTags(),
+  ]);
+
   return (
-    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
-      <BookMarked size={48} style={{ color: "var(--text-muted)" }} />
-      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
-        Przepisy
-      </h2>
-      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
-        Wkrótce — Faza 1. Biblioteka przepisów z filtrami i tagami.
-      </p>
-    </div>
+    <RecipeList
+      recipes={recipes}
+      tags={tags}
+      cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+    />
   );
 }

--- a/worldofmag/src/app/kitchen/recipes/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/page.tsx
@@ -1,0 +1,17 @@
+import { BookMarked } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default function KitchenRecipesPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+      <BookMarked size={48} style={{ color: "var(--text-muted)" }} />
+      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Przepisy
+      </h2>
+      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+        Wkrótce — Faza 1. Biblioteka przepisów z filtrami i tagami.
+      </p>
+    </div>
+  );
+}

--- a/worldofmag/src/app/kitchen/recipes/page.tsx
+++ b/worldofmag/src/app/kitchen/recipes/page.tsx
@@ -16,12 +16,14 @@ export default async function KitchenRecipesPage() {
     getCookbooks(),
     getTags(),
   ]);
+  const hasAI = session.user.permissions?.includes("kitchen.ai") ?? false;
 
   return (
     <RecipeList
       recipes={recipes}
       tags={tags}
       cookbooks={cookbooks.map((cb) => ({ id: cb.id, name: cb.name, emoji: cb.emoji }))}
+      hasAI={hasAI}
     />
   );
 }

--- a/worldofmag/src/app/page.tsx
+++ b/worldofmag/src/app/page.tsx
@@ -4,7 +4,9 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getRecentActivity } from "@/actions/activity";
-import { HomePage } from "@/components/home/HomePage";
+import { getTodaysMeals } from "@/actions/mealPlans";
+import { getExpiringSoon } from "@/actions/pantry";
+import { HomePage, type KitchenWidgetData } from "@/components/home/HomePage";
 
 export default async function HomePageRoute() {
   const session = await auth();
@@ -47,6 +49,31 @@ export default async function HomePageRoute() {
   const userRoles: string[] = session.user.roles ?? [];
   const userPermissions: string[] = session.user.permissions ?? [];
 
+  let kitchenWidget: KitchenWidgetData | null = null;
+  if (userPermissions.includes("module.kitchen")) {
+    try {
+      const [todayMeals, expiring] = await Promise.all([getTodaysMeals(), getExpiringSoon(3)]);
+      kitchenWidget = {
+        todayMeals: todayMeals.map((m) => ({
+          id: m.id,
+          slot: m.slot,
+          title: m.recipe?.title ?? m.customTitle ?? "—",
+          servings: m.servings,
+          recipeSlug: m.recipe?.slug ?? null,
+        })),
+        expiring: expiring.slice(0, 3).map((e) => {
+          const d = e.expiresAt ? new Date(e.expiresAt) : null;
+          const days = d
+            ? Math.floor((d.getTime() - todayStart.getTime()) / (1000 * 60 * 60 * 24))
+            : 0;
+          return { id: e.id, name: e.name, daysLeft: days };
+        }),
+      };
+    } catch {
+      kitchenWidget = null;
+    }
+  }
+
   return (
     <HomePage
       userName={session.user.name ?? null}
@@ -56,6 +83,7 @@ export default async function HomePageRoute() {
       recentActivity={recentActivity}
       userRoles={userRoles}
       userPermissions={userPermissions}
+      kitchenWidget={kitchenWidget}
     />
   );
 }

--- a/worldofmag/src/components/home/HomePage.tsx
+++ b/worldofmag/src/components/home/HomePage.tsx
@@ -4,11 +4,17 @@ import Link from "next/link";
 import { Sparkles, BookOpen, Lock } from "lucide-react";
 import { QuickStats } from "@/components/home/QuickStats";
 import { AISuggestions } from "@/components/home/AISuggestions";
+import { KitchenWidget } from "@/components/home/KitchenWidget";
 
 interface ActivityItem {
   module: string;
   action: string;
   createdAt: Date;
+}
+
+export interface KitchenWidgetData {
+  todayMeals: Array<{ id: string; slot: string; title: string; servings: number; recipeSlug: string | null }>;
+  expiring: Array<{ id: string; name: string; daysLeft: number }>;
 }
 
 interface HomePageProps {
@@ -19,6 +25,7 @@ interface HomePageProps {
   recentActivity: ActivityItem[];
   userRoles: string[];
   userPermissions?: string[];
+  kitchenWidget?: KitchenWidgetData | null;
 }
 
 function getGreeting(name: string | null): string {
@@ -53,8 +60,9 @@ function FooterLink({ href, label, locked }: FooterLinkProps) {
   );
 }
 
-export function HomePage({ userName, pendingItems, todayTasks, overdueTasks, recentActivity, userRoles, userPermissions = [] }: HomePageProps) {
+export function HomePage({ userName, pendingItems, todayTasks, overdueTasks, recentActivity, userRoles, userPermissions = [], kitchenWidget }: HomePageProps) {
   const isBetaOnly = !userPermissions.includes("module.tasks");
+  const kitchenLocked = !userPermissions.includes("module.kitchen");
 
   return (
     <div
@@ -94,6 +102,15 @@ export function HomePage({ userName, pendingItems, todayTasks, overdueTasks, rec
           overdueTasks={overdueTasks}
           locked={isBetaOnly}
         />
+
+        {/* Kitchen widget */}
+        {kitchenWidget ? (
+          <KitchenWidget
+            todayMeals={kitchenWidget.todayMeals}
+            expiring={kitchenWidget.expiring}
+            locked={kitchenLocked}
+          />
+        ) : null}
 
         {/* AI suggestions */}
         <AISuggestions recentActivity={recentActivity} overdueTasks={overdueTasks} locked={isBetaOnly} />

--- a/worldofmag/src/components/home/KitchenWidget.tsx
+++ b/worldofmag/src/components/home/KitchenWidget.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { ChefHat, AlertTriangle, Clock, Users } from "lucide-react";
+
+interface TodayMealItem {
+  id: string;
+  slot: string;
+  title: string;
+  servings: number;
+  recipeSlug: string | null;
+}
+
+interface ExpiringItem {
+  id: string;
+  name: string;
+  daysLeft: number;
+}
+
+interface KitchenWidgetProps {
+  todayMeals: TodayMealItem[];
+  expiring: ExpiringItem[];
+  locked?: boolean;
+}
+
+const SLOT_EMOJI: Record<string, string> = {
+  breakfast: "☕",
+  lunch: "🍽",
+  dinner: "🌙",
+  snack: "🍪",
+};
+
+const SLOT_LABELS: Record<string, string> = {
+  breakfast: "Śniadanie",
+  lunch: "Obiad",
+  dinner: "Kolacja",
+  snack: "Przekąska",
+};
+
+function expiryColor(daysLeft: number): string {
+  if (daysLeft < 0) return "var(--kitchen-expired)";
+  if (daysLeft <= 1) return "var(--kitchen-expired)";
+  if (daysLeft <= 3) return "var(--kitchen-expiring)";
+  return "var(--text-muted)";
+}
+
+function expiryText(daysLeft: number): string {
+  if (daysLeft < 0) return "przeterminowane";
+  if (daysLeft === 0) return "dziś";
+  if (daysLeft === 1) return "jutro";
+  return `za ${daysLeft} dni`;
+}
+
+export function KitchenWidget({ todayMeals, expiring, locked }: KitchenWidgetProps) {
+  if (locked) return null;
+  if (todayMeals.length === 0 && expiring.length === 0) return null;
+
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        padding: 16,
+        borderRadius: 12,
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h2 style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, fontWeight: 600, color: "var(--accent-orange)", margin: 0, textTransform: "uppercase", letterSpacing: 0.5 }}>
+          <ChefHat size={14} /> Kuchnia
+        </h2>
+        <Link href="/kitchen/plan" style={{ fontSize: 12, color: "var(--text-muted)" }}>
+          Plan →
+        </Link>
+      </div>
+
+      {todayMeals.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <h3 style={{ fontSize: 11, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: 0.5, margin: 0 }}>
+            <Clock size={10} style={{ marginRight: 4, verticalAlign: "middle" }} />
+            Co dziś gotujemy
+          </h3>
+          {todayMeals.map((m) => {
+            const Tag = m.recipeSlug ? Link : "div";
+            const props = m.recipeSlug ? { href: `/kitchen/recipes/${m.recipeSlug}` } : {};
+            return (
+              <Tag
+                key={m.id}
+                {...(props as { href: string })}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "8px 10px",
+                  borderRadius: 8,
+                  backgroundColor: "var(--bg-elevated)",
+                  textDecoration: "none",
+                  color: "var(--text-primary)",
+                  fontSize: 13,
+                }}
+              >
+                <span>{SLOT_EMOJI[m.slot] ?? "🍽"}</span>
+                <span style={{ fontSize: 11, color: "var(--text-muted)", minWidth: 56 }}>
+                  {SLOT_LABELS[m.slot] ?? m.slot}
+                </span>
+                <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {m.title}
+                </span>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 2, fontSize: 11, color: "var(--text-muted)" }}>
+                  <Users size={10} /> {m.servings}
+                </span>
+              </Tag>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {expiring.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <h3 style={{ fontSize: 11, color: "var(--kitchen-expiring)", textTransform: "uppercase", letterSpacing: 0.5, margin: 0 }}>
+            <AlertTriangle size={10} style={{ marginRight: 4, verticalAlign: "middle" }} />
+            Kończy się termin
+          </h3>
+          {expiring.map((e) => (
+            <Link
+              key={e.id}
+              href="/kitchen/pantry"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "6px 10px",
+                borderRadius: 8,
+                backgroundColor: "var(--bg-elevated)",
+                fontSize: 13,
+                color: "var(--text-primary)",
+                textDecoration: "none",
+              }}
+            >
+              <span>{e.name}</span>
+              <span style={{ fontSize: 11, color: expiryColor(e.daysLeft) }}>{expiryText(e.daysLeft)}</span>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/worldofmag/src/components/kitchen/KitchenLayout.tsx
+++ b/worldofmag/src/components/kitchen/KitchenLayout.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BookMarked, CalendarDays, Package, BookOpen, ChefHat } from "lucide-react";
+
+interface KitchenLayoutProps {
+  children: React.ReactNode;
+}
+
+const TABS = [
+  { href: "/kitchen/recipes", label: "Przepisy", icon: BookMarked },
+  { href: "/kitchen/plan", label: "Plan", icon: CalendarDays },
+  { href: "/kitchen/pantry", label: "Spiżarnia", icon: Package },
+  { href: "/kitchen/cookbooks", label: "Książki", icon: BookOpen },
+];
+
+export function KitchenLayout({ children }: KitchenLayoutProps) {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <header
+        className="flex-shrink-0 border-b"
+        style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+      >
+        <div className="hidden md:flex items-center gap-2 px-6 py-3">
+          <ChefHat size={20} style={{ color: "var(--accent-orange)" }} />
+          <h1 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+            Kuchnia
+          </h1>
+        </div>
+        <nav className="flex items-center gap-1 px-3 md:px-6 py-1 overflow-x-auto">
+          {TABS.map(({ href, label, icon: Icon }) => {
+            const isActive = pathname === href || pathname.startsWith(href + "/");
+            return (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center gap-2 px-3 py-2 rounded text-sm whitespace-nowrap"
+                style={{
+                  backgroundColor: isActive ? "var(--bg-elevated)" : "transparent",
+                  color: isActive ? "var(--accent-orange)" : "var(--text-secondary)",
+                }}
+              >
+                <Icon size={16} />
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      </header>
+      <div className="flex-1 overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/pantry/PantryEditSheet.tsx
+++ b/worldofmag/src/components/kitchen/pantry/PantryEditSheet.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { X, Trash2 } from "lucide-react";
+import { addPantryItem, updatePantryItem, deletePantryItem } from "@/actions/pantry";
+import { useToast } from "@/components/ui/Toast";
+import type { PantryItemWithProduct } from "@/actions/pantry";
+
+const LOCATION_OPTIONS = ["spiżarnia", "lodówka", "zamrażarka", "przyprawy", "inne"];
+
+interface PantryEditSheetProps {
+  open: boolean;
+  onClose: () => void;
+  item?: PantryItemWithProduct | null;
+  defaultLocation?: string | null;
+}
+
+function toDateInput(d: Date | null | undefined): string {
+  if (!d) return "";
+  const date = new Date(d);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function PantryEditSheet({ open, onClose, item, defaultLocation }: PantryEditSheetProps) {
+  const [name, setName] = useState(item?.name ?? "");
+  const [quantity, setQuantity] = useState<string>(item?.quantity?.toString() ?? "");
+  const [unit, setUnit] = useState(item?.unit ?? "");
+  const [location, setLocation] = useState(item?.location ?? defaultLocation ?? "spiżarnia");
+  const [expiresAt, setExpiresAt] = useState<string>(toDateInput(item?.expiresAt));
+  const [minQuantity, setMinQuantity] = useState<string>(item?.minQuantity?.toString() ?? "");
+  const [autoShop, setAutoShop] = useState<boolean>(item?.autoShop ?? false);
+  const [pending, startTransition] = useTransition();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (open) {
+      setName(item?.name ?? "");
+      setQuantity(item?.quantity?.toString() ?? "");
+      setUnit(item?.unit ?? "");
+      setLocation(item?.location ?? defaultLocation ?? "spiżarnia");
+      setExpiresAt(toDateInput(item?.expiresAt));
+      setMinQuantity(item?.minQuantity?.toString() ?? "");
+      setAutoShop(item?.autoShop ?? false);
+    }
+  }, [open, item, defaultLocation]);
+
+  if (!open) return null;
+
+  function handleSave() {
+    if (!name.trim()) {
+      showToast("Nazwa jest wymagana", "error");
+      return;
+    }
+    const payload = {
+      name: name.trim(),
+      quantity: quantity ? Number(quantity) : null,
+      unit: unit.trim() || null,
+      location: location || null,
+      expiresAt: expiresAt ? new Date(`${expiresAt}T12:00:00`) : null,
+      minQuantity: minQuantity ? Number(minQuantity) : null,
+      autoShop,
+    };
+    startTransition(async () => {
+      try {
+        if (item) await updatePantryItem(item.id, payload);
+        else await addPantryItem(payload);
+        showToast("Zapisano", "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!item) return;
+    if (!confirm("Usunąć tę pozycję ze spiżarni?")) return;
+    startTransition(async () => {
+      try {
+        await deletePantryItem(item.id);
+        showToast("Usunięto", "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:w-[480px] md:rounded border max-h-[90vh] overflow-y-auto"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          borderColor: "var(--border)",
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "var(--border)" }}>
+          <h3 className="text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            {item ? "Edytuj pozycję" : "Nowa pozycja"}
+          </h3>
+          <button onClick={onClose} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          <Field label="Nazwa">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+              className="w-full px-3 py-2 rounded border text-sm"
+              style={inputStyle}
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-2">
+            <Field label="Ilość">
+              <input
+                type="number"
+                step="any"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                className="w-full px-2 py-1.5 rounded border text-sm"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Jednostka">
+              <input
+                type="text"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+                placeholder="szt, g, ml…"
+                className="w-full px-2 py-1.5 rounded border text-sm"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+          <Field label="Lokalizacja">
+            <select
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            >
+              {LOCATION_OPTIONS.map((l) => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Termin ważności">
+            <input
+              type="date"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            />
+          </Field>
+          <div className="grid grid-cols-[1fr_auto] gap-2 items-end">
+            <Field label="Minimum (auto-uzupełnianie)">
+              <input
+                type="number"
+                step="any"
+                value={minQuantity}
+                onChange={(e) => setMinQuantity(e.target.value)}
+                placeholder="np. 0.5"
+                className="w-full px-2 py-1.5 rounded border text-sm"
+                style={inputStyle}
+              />
+            </Field>
+            <label className="flex items-center gap-1.5 text-xs px-1 py-1.5" style={{ color: "var(--text-secondary)" }}>
+              <input
+                type="checkbox"
+                checked={autoShop}
+                onChange={(e) => setAutoShop(e.target.checked)}
+              />
+              Auto-uzupełnij
+            </label>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 px-4 py-3 border-t" style={{ borderColor: "var(--border)" }}>
+          <div>
+            {item ? (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={pending}
+                className="inline-flex items-center gap-1 px-2 py-1.5 rounded text-xs disabled:opacity-50"
+                style={{ color: "var(--accent-red)" }}
+              >
+                <Trash2 size={14} /> Usuń
+              </button>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={onClose} className="px-3 py-1.5 rounded text-sm" style={{ color: "var(--text-secondary)" }}>
+              Anuluj
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={pending}
+              className="px-3 py-1.5 rounded text-sm disabled:opacity-50"
+              style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+            >
+              {pending ? "Zapisuję…" : "Zapisz"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  backgroundColor: "var(--bg-elevated)",
+  borderColor: "var(--border)",
+  color: "var(--text-primary)",
+};

--- a/worldofmag/src/components/kitchen/pantry/PantryList.tsx
+++ b/worldofmag/src/components/kitchen/pantry/PantryList.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Plus, Search, Package, AlertTriangle, ClipboardList } from "lucide-react";
+import { PantryEditSheet } from "./PantryEditSheet";
+import type { PantryItemWithProduct } from "@/actions/pantry";
+
+interface PantryListProps {
+  items: PantryItemWithProduct[];
+  expiringSoon: PantryItemWithProduct[];
+}
+
+const LOCATION_ICON: Record<string, string> = {
+  spiżarnia: "🥫",
+  lodówka: "❄️",
+  zamrażarka: "🧊",
+  przyprawy: "🌿",
+  inne: "📦",
+};
+
+function formatExpiry(date: Date | null): { text: string; color: string } | null {
+  if (!date) return null;
+  const d = new Date(date);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const diff = Math.floor((d.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (diff < 0) return { text: "przeterminowane", color: "var(--kitchen-expired)" };
+  if (diff === 0) return { text: "dziś", color: "var(--kitchen-expired)" };
+  if (diff === 1) return { text: "jutro", color: "var(--kitchen-expiring)" };
+  if (diff <= 3) return { text: `za ${diff} dni`, color: "var(--kitchen-expiring)" };
+  if (diff <= 7) return { text: `za ${diff} dni`, color: "var(--text-secondary)" };
+  return { text: d.toLocaleDateString("pl-PL"), color: "var(--text-muted)" };
+}
+
+export function PantryList({ items, expiringSoon }: PantryListProps) {
+  const [search, setSearch] = useState("");
+  const [activeLocation, setActiveLocation] = useState<string>("");
+  const [editing, setEditing] = useState<{ item: PantryItemWithProduct | null; location?: string } | null>(null);
+
+  const grouped = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const filtered = items.filter((i) => {
+      if (q && !i.name.toLowerCase().includes(q)) return false;
+      if (activeLocation && (i.location ?? "spiżarnia") !== activeLocation) return false;
+      return true;
+    });
+    const map = new Map<string, PantryItemWithProduct[]>();
+    for (const i of filtered) {
+      const loc = i.location ?? "spiżarnia";
+      if (!map.has(loc)) map.set(loc, []);
+      map.get(loc)!.push(i);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [items, search, activeLocation]);
+
+  const locations = useMemo(() => {
+    const set = new Set<string>();
+    for (const i of items) set.add(i.location ?? "spiżarnia");
+    return Array.from(set).sort();
+  }, [items]);
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+        <Package size={48} style={{ color: "var(--text-muted)" }} />
+        <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+          Spiżarnia jest pusta
+        </h2>
+        <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+          Dodaj pierwszą pozycję, żeby zacząć śledzić swój zapas. Pozycje ze spiżarni będą automatycznie pomijane przy generowaniu listy zakupów.
+        </p>
+        <button
+          type="button"
+          onClick={() => setEditing({ item: null })}
+          className="mt-6 inline-flex items-center gap-1.5 px-4 py-2 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Plus size={16} /> Dodaj pozycję
+        </button>
+        {editing ? <PantryEditSheet open onClose={() => setEditing(null)} item={null} /> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-4 flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 flex-1 px-3 py-2 rounded border"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+        >
+          <Search size={14} style={{ color: "var(--text-muted)" }} />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Szukaj w spiżarni…"
+            className="flex-1 bg-transparent border-none outline-none text-sm"
+            style={{ color: "var(--text-primary)" }}
+          />
+        </div>
+        <Link
+          href="/kitchen/pantry/stocktake"
+          className="inline-flex items-center gap-1 px-2.5 py-2 rounded border text-sm whitespace-nowrap"
+          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+          title="Inwentaryzacja"
+        >
+          <ClipboardList size={14} /> Stocktake
+        </Link>
+        <button
+          type="button"
+          onClick={() => setEditing({ item: null })}
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Plus size={16} /> Dodaj
+        </button>
+      </div>
+
+      <div className="flex items-center gap-1 overflow-x-auto">
+        <button
+          type="button"
+          onClick={() => setActiveLocation("")}
+          className="px-2.5 py-1 rounded text-xs whitespace-nowrap"
+          style={{
+            backgroundColor: activeLocation === "" ? "var(--accent-orange)" : "var(--bg-surface)",
+            color: activeLocation === "" ? "#0d0d0d" : "var(--text-secondary)",
+          }}
+        >
+          Wszystko
+        </button>
+        {locations.map((loc) => {
+          const isActive = activeLocation === loc;
+          return (
+            <button
+              key={loc}
+              type="button"
+              onClick={() => setActiveLocation(loc)}
+              className="px-2.5 py-1 rounded text-xs whitespace-nowrap"
+              style={{
+                backgroundColor: isActive ? "var(--accent-orange)" : "var(--bg-surface)",
+                color: isActive ? "#0d0d0d" : "var(--text-secondary)",
+              }}
+            >
+              {LOCATION_ICON[loc] ?? "📦"} {loc}
+            </button>
+          );
+        })}
+      </div>
+
+      {expiringSoon.length > 0 ? (
+        <section
+          className="rounded border p-3"
+          style={{ borderColor: "var(--kitchen-expiring)", backgroundColor: "rgba(255, 152, 0, 0.06)" }}
+        >
+          <h3
+            className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide mb-2"
+            style={{ color: "var(--kitchen-expiring)" }}
+          >
+            <AlertTriangle size={12} /> Termin ważności ({expiringSoon.length})
+          </h3>
+          <div className="flex flex-col gap-1">
+            {expiringSoon.map((i) => {
+              const exp = formatExpiry(i.expiresAt);
+              return (
+                <button
+                  key={i.id}
+                  type="button"
+                  onClick={() => setEditing({ item: i })}
+                  className="flex items-center justify-between text-sm text-left px-2 py-1 rounded"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  <span>
+                    {i.name}
+                    {i.quantity != null ? (
+                      <span style={{ color: "var(--text-muted)" }}>
+                        {" "}
+                        — {i.quantity}{i.unit ? ` ${i.unit}` : ""}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="text-xs" style={{ color: exp?.color ?? "var(--text-muted)" }}>
+                    {exp?.text}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      <div className="flex flex-col gap-4">
+        {grouped.length === 0 ? (
+          <p className="text-sm py-6 text-center" style={{ color: "var(--text-muted)" }}>
+            Brak pozycji.
+          </p>
+        ) : null}
+        {grouped.map(([loc, list]) => (
+          <section key={loc}>
+            <h3 className="text-xs font-semibold uppercase tracking-wide mb-1.5" style={{ color: "var(--text-muted)" }}>
+              {LOCATION_ICON[loc] ?? "📦"} {loc} ({list.length})
+            </h3>
+            <ul className="flex flex-col gap-0.5">
+              {list.map((i) => {
+                const exp = formatExpiry(i.expiresAt);
+                const belowMin = i.minQuantity != null && (i.quantity ?? 0) < i.minQuantity;
+                return (
+                  <li key={i.id}>
+                    <button
+                      type="button"
+                      onClick={() => setEditing({ item: i })}
+                      className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded text-sm text-left"
+                      style={{ backgroundColor: "var(--bg-surface)", color: "var(--text-primary)" }}
+                    >
+                      <span className="flex-1 min-w-0 truncate">{i.name}</span>
+                      <span className="text-xs tabular-nums" style={{ color: "var(--text-secondary)" }}>
+                        {i.quantity != null ? `${i.quantity}${i.unit ? ` ${i.unit}` : ""}` : "—"}
+                      </span>
+                      {belowMin ? (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ backgroundColor: "var(--kitchen-expiring)", color: "#0d0d0d" }}>
+                          poniżej min
+                        </span>
+                      ) : null}
+                      {exp ? (
+                        <span className="text-[10px] tabular-nums" style={{ color: exp.color }}>
+                          {exp.text}
+                        </span>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      {editing ? (
+        <PantryEditSheet
+          open
+          onClose={() => setEditing(null)}
+          item={editing.item}
+          defaultLocation={editing.location ?? (activeLocation || null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/pantry/StockTakeMode.tsx
+++ b/worldofmag/src/components/kitchen/pantry/StockTakeMode.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Save } from "lucide-react";
+import { bulkSetPantryQuantities } from "@/actions/pantry";
+import { useToast } from "@/components/ui/Toast";
+import type { PantryItemWithProduct } from "@/actions/pantry";
+
+interface StockTakeModeProps {
+  items: PantryItemWithProduct[];
+}
+
+const LOCATION_ICON: Record<string, string> = {
+  spiżarnia: "🥫",
+  lodówka: "❄️",
+  zamrażarka: "🧊",
+  przyprawy: "🌿",
+  inne: "📦",
+};
+
+export function StockTakeMode({ items }: StockTakeModeProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [pending, startTransition] = useTransition();
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(items.map((i) => [i.id, i.quantity?.toString() ?? ""]))
+  );
+
+  const grouped = items.reduce<Record<string, PantryItemWithProduct[]>>((acc, i) => {
+    const loc = i.location ?? "spiżarnia";
+    if (!acc[loc]) acc[loc] = [];
+    acc[loc].push(i);
+    return acc;
+  }, {});
+
+  function handleSave() {
+    const updates = Object.entries(values)
+      .map(([id, v]) => ({ id, quantity: v === "" ? null : Number(v) }))
+      .filter((u) => {
+        const original = items.find((i) => i.id === u.id);
+        return original && original.quantity !== u.quantity;
+      });
+    if (updates.length === 0) {
+      showToast("Brak zmian do zapisania", "info");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await bulkSetPantryQuantities(updates);
+        showToast(`Zaktualizowano ${updates.length} pozycji`, "success");
+        router.push("/kitchen/pantry");
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd zapisu", "error");
+      }
+    });
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-4 max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="inline-flex items-center gap-1 text-sm"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft size={14} /> Anuluj
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={pending}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm disabled:opacity-50"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Save size={14} /> {pending ? "Zapisuję…" : "Zapisz wszystko"}
+        </button>
+      </div>
+
+      <h1 className="text-lg font-semibold mb-1" style={{ color: "var(--text-primary)" }}>
+        Inwentaryzacja
+      </h1>
+      <p className="text-sm mb-4" style={{ color: "var(--text-secondary)" }}>
+        Wpisz aktualną ilość każdego produktu. Tab/Enter przechodzi do kolejnego pola.
+      </p>
+
+      <div className="flex flex-col gap-4">
+        {Object.entries(grouped).map(([loc, list]) => (
+          <section key={loc}>
+            <h3 className="text-xs font-semibold uppercase tracking-wide mb-1.5" style={{ color: "var(--text-muted)" }}>
+              {LOCATION_ICON[loc] ?? "📦"} {loc}
+            </h3>
+            <div className="flex flex-col gap-1">
+              {list.map((i) => (
+                <div
+                  key={i.id}
+                  className="flex items-center gap-2 px-3 py-2 rounded border"
+                  style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+                >
+                  <span className="flex-1 min-w-0 truncate text-sm" style={{ color: "var(--text-primary)" }}>
+                    {i.name}
+                  </span>
+                  <input
+                    type="number"
+                    step="any"
+                    value={values[i.id] ?? ""}
+                    onChange={(e) => setValues((prev) => ({ ...prev, [i.id]: e.target.value }))}
+                    className="w-20 px-2 py-1 rounded border text-sm tabular-nums text-right"
+                    style={{
+                      backgroundColor: "var(--bg-elevated)",
+                      borderColor: "var(--border)",
+                      color: "var(--text-primary)",
+                    }}
+                  />
+                  <span className="text-xs w-12" style={{ color: "var(--text-muted)" }}>
+                    {i.unit ?? ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        {items.length === 0 ? (
+          <p className="text-sm text-center py-10" style={{ color: "var(--text-muted)" }}>
+            Brak pozycji do inwentaryzacji.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/plan/MealPlanWeek.tsx
+++ b/worldofmag/src/components/kitchen/plan/MealPlanWeek.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { ChevronLeft, ChevronRight, ShoppingCart, Plus, CheckCircle2 } from "lucide-react";
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { addDays, subDays } from "date-fns";
+import { useToast } from "@/components/ui/Toast";
+import { moveMealPlanEntry } from "@/actions/mealPlans";
+import { SlotEditorSheet, type RecipePickerItem } from "./SlotEditorSheet";
+import { ShoppingFromPlanDialog } from "./ShoppingFromPlanDialog";
+import type { MealPlanEntryWithRecipe } from "@/actions/mealPlans";
+import type { MealSlot } from "@/types/kitchen";
+import { MEAL_SLOTS, MEAL_SLOT_LABELS } from "@/types/kitchen";
+import {
+  getWeekStart,
+  getWeekDays,
+  getWeekEnd,
+  formatWeekRange,
+  formatDayShort,
+  dateKey,
+  isToday,
+} from "@/lib/kitchenDate";
+
+interface MealPlanWeekProps {
+  initialWeek: string; // YYYY-MM-DD anchor (any date in week)
+  entries: MealPlanEntryWithRecipe[];
+  recipes: RecipePickerItem[];
+  lists: Array<{ id: string; name: string }>;
+}
+
+const SLOT_EMOJI: Record<MealSlot, string> = {
+  breakfast: "☕",
+  lunch: "🍽",
+  dinner: "🌙",
+  snack: "🍪",
+};
+
+interface SlotMatrix {
+  [dateKey: string]: { [slot in MealSlot]?: MealPlanEntryWithRecipe };
+}
+
+function buildMatrix(entries: MealPlanEntryWithRecipe[]): SlotMatrix {
+  const matrix: SlotMatrix = {};
+  for (const e of entries) {
+    const k = dateKey(new Date(e.date));
+    if (!matrix[k]) matrix[k] = {};
+    matrix[k][e.slot as MealSlot] = e;
+  }
+  return matrix;
+}
+
+function entryLabel(e: MealPlanEntryWithRecipe): string {
+  return e.recipe?.title ?? e.customTitle ?? "—";
+}
+
+export function MealPlanWeek({ initialWeek, entries, recipes, lists }: MealPlanWeekProps) {
+  const [anchorDate, setAnchorDate] = useState<Date>(() => new Date(`${initialWeek}T12:00:00`));
+  const [editing, setEditing] = useState<{ date: Date; slot: MealSlot; entry?: MealPlanEntryWithRecipe | null } | null>(null);
+  const [shoppingOpen, setShoppingOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const { showToast } = useToast();
+
+  const weekDays = useMemo(() => getWeekDays(anchorDate), [anchorDate]);
+  const matrix = useMemo(() => buildMatrix(entries), [entries]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const entryId = String(event.active.id);
+    const overId = event.over?.id ? String(event.over.id) : null;
+    if (!overId) return;
+    const [dateStr, slot] = overId.split("::");
+    if (!dateStr || !slot) return;
+    const target = new Date(`${dateStr}T12:00:00`);
+    startTransition(async () => {
+      try {
+        await moveMealPlanEntry(entryId, target, slot as MealSlot);
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd przenoszenia", "error");
+      }
+    });
+  }
+
+  function goPrev() {
+    setAnchorDate((d) => subDays(d, 7));
+  }
+  function goNext() {
+    setAnchorDate((d) => addDays(d, 7));
+  }
+  function goToday() {
+    setAnchorDate(new Date());
+  }
+
+  function openEditor(date: Date, slot: MealSlot, entry?: MealPlanEntryWithRecipe) {
+    setEditing({ date, slot, entry });
+  }
+
+  return (
+    <div className="px-3 md:px-6 py-3 md:py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={goPrev}
+            className="w-8 h-8 rounded flex items-center justify-center"
+            style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+            aria-label="Poprzedni tydzień"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={goToday}
+            className="px-3 h-8 rounded text-sm"
+            style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+          >
+            Dziś
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            className="w-8 h-8 rounded flex items-center justify-center"
+            style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+            aria-label="Następny tydzień"
+          >
+            <ChevronRight size={16} />
+          </button>
+          <span className="ml-2 text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+            {formatWeekRange(anchorDate)}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShoppingOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <ShoppingCart size={14} /> Lista zakupów z planu
+        </button>
+      </div>
+
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        {/* Desktop: grid 7 cols × 4 slot rows */}
+        <div
+          className="hidden md:grid gap-1 border rounded overflow-hidden"
+          style={{
+            gridTemplateColumns: "100px repeat(7, minmax(0, 1fr))",
+            borderColor: "var(--border)",
+            backgroundColor: "var(--border)",
+          }}
+        >
+          <div style={{ backgroundColor: "var(--bg-surface)" }} />
+          {weekDays.map((d) => (
+            <div
+              key={dateKey(d)}
+              className="px-2 py-1.5 text-xs font-medium text-center"
+              style={{
+                backgroundColor: "var(--bg-surface)",
+                color: isToday(d) ? "var(--accent-orange)" : "var(--text-secondary)",
+              }}
+            >
+              {formatDayShort(d)}
+            </div>
+          ))}
+
+          {MEAL_SLOTS.map((slot) => (
+            <ShellRow key={slot}>
+              <SlotLabel slot={slot} />
+              {weekDays.map((d) => {
+                const k = dateKey(d);
+                const entry = matrix[k]?.[slot];
+                return (
+                  <SlotCell
+                    key={`${k}::${slot}`}
+                    id={`${k}::${slot}`}
+                    onClick={() => openEditor(d, slot, entry)}
+                    isToday={isToday(d)}
+                  >
+                    {entry ? <DraggableEntry entry={entry} /> : <EmptySlot />}
+                  </SlotCell>
+                );
+              })}
+            </ShellRow>
+          ))}
+        </div>
+
+        {/* Mobile: list dni */}
+        <div className="md:hidden flex flex-col gap-3">
+          {weekDays.map((d) => {
+            const k = dateKey(d);
+            return (
+              <div
+                key={k}
+                className="rounded border"
+                style={{ borderColor: isToday(d) ? "var(--accent-orange)" : "var(--border)", backgroundColor: "var(--bg-surface)" }}
+              >
+                <div
+                  className="px-3 py-2 text-sm font-semibold border-b"
+                  style={{
+                    color: isToday(d) ? "var(--accent-orange)" : "var(--text-primary)",
+                    borderColor: "var(--border)",
+                  }}
+                >
+                  {formatDayShort(d)}
+                </div>
+                <div className="flex flex-col gap-1 p-2">
+                  {MEAL_SLOTS.map((slot) => {
+                    const entry = matrix[k]?.[slot];
+                    return (
+                      <button
+                        key={slot}
+                        type="button"
+                        onClick={() => openEditor(d, slot, entry)}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left"
+                        style={{
+                          backgroundColor: "var(--bg-elevated)",
+                          color: entry ? "var(--text-primary)" : "var(--text-muted)",
+                        }}
+                      >
+                        <span>{SLOT_EMOJI[slot]}</span>
+                        <span className="text-xs" style={{ color: "var(--text-muted)" }}>{MEAL_SLOT_LABELS[slot]}</span>
+                        <span className="flex-1 truncate ml-1">
+                          {entry ? (
+                            <>
+                              {entryLabel(entry)} <span style={{ color: "var(--text-muted)" }}>· {entry.servings}p</span>
+                            </>
+                          ) : (
+                            "—"
+                          )}
+                        </span>
+                        {entry?.status === "COOKED" ? (
+                          <CheckCircle2 size={14} style={{ color: "var(--accent-green)" }} />
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </DndContext>
+
+      {editing ? (
+        <SlotEditorSheet
+          open
+          onClose={() => setEditing(null)}
+          date={editing.date}
+          slot={editing.slot}
+          entry={editing.entry}
+          recipes={recipes}
+        />
+      ) : null}
+
+      <ShoppingFromPlanDialog
+        open={shoppingOpen}
+        onClose={() => setShoppingOpen(false)}
+        defaultFrom={getWeekStart(anchorDate)}
+        defaultTo={getWeekEnd(anchorDate)}
+        lists={lists}
+      />
+
+      {pending ? (
+        <div className="fixed bottom-4 right-4 text-xs px-3 py-1.5 rounded" style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}>
+          Synchronizuję…
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ShellRow({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function SlotLabel({ slot }: { slot: MealSlot }) {
+  return (
+    <div
+      className="px-2 py-2 text-xs font-medium flex items-center gap-1"
+      style={{ backgroundColor: "var(--bg-surface)", color: "var(--text-secondary)" }}
+    >
+      <span>{SLOT_EMOJI[slot]}</span>
+      {MEAL_SLOT_LABELS[slot]}
+    </div>
+  );
+}
+
+function SlotCell({
+  id,
+  onClick,
+  isToday,
+  children,
+}: {
+  id: string;
+  onClick: () => void;
+  isToday: boolean;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id });
+  return (
+    <div
+      ref={setNodeRef}
+      onClick={onClick}
+      className="px-1.5 py-1.5 min-h-[64px] cursor-pointer"
+      style={{
+        backgroundColor: isOver
+          ? "var(--bg-hover)"
+          : isToday
+          ? "rgba(255, 138, 61, 0.08)"
+          : "var(--bg-surface)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EmptySlot() {
+  return (
+    <div className="flex items-center justify-center h-full text-xs" style={{ color: "var(--text-muted)" }}>
+      <Plus size={14} />
+    </div>
+  );
+}
+
+function DraggableEntry({ entry }: { entry: MealPlanEntryWithRecipe }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: entry.id });
+  const isCooked = entry.status === "COOKED";
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      onClick={(e) => e.stopPropagation()}
+      className="text-xs px-2 py-1 rounded"
+      style={{
+        backgroundColor: isCooked ? "var(--bg-elevated)" : "rgba(255, 138, 61, 0.16)",
+        color: isCooked ? "var(--text-muted)" : "var(--text-primary)",
+        opacity: isDragging ? 0.5 : 1,
+        cursor: "grab",
+        lineHeight: 1.3,
+      }}
+    >
+      <div className="font-medium truncate">{entryLabel(entry)}</div>
+      <div className="flex items-center justify-between text-[10px]" style={{ color: "var(--text-muted)" }}>
+        <span>{entry.servings}p</span>
+        {isCooked ? <CheckCircle2 size={10} style={{ color: "var(--accent-green)" }} /> : null}
+      </div>
+    </div>
+  );
+}
+

--- a/worldofmag/src/components/kitchen/plan/ShoppingFromPlanDialog.tsx
+++ b/worldofmag/src/components/kitchen/plan/ShoppingFromPlanDialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { X, ShoppingCart } from "lucide-react";
+import { generateShoppingListFromPlan } from "@/actions/mealPlans";
+import { useToast } from "@/components/ui/Toast";
+
+interface ShoppingFromPlanDialogProps {
+  open: boolean;
+  onClose: () => void;
+  defaultFrom: Date;
+  defaultTo: Date;
+  lists: Array<{ id: string; name: string }>;
+}
+
+export function ShoppingFromPlanDialog({
+  open,
+  onClose,
+  defaultFrom,
+  defaultTo,
+  lists,
+}: ShoppingFromPlanDialogProps) {
+  const [listId, setListId] = useState<string>(lists[0]?.id ?? "");
+  const [skipPantry, setSkipPantry] = useState(true);
+  const [consolidate, setConsolidate] = useState(true);
+  const [skipOptional, setSkipOptional] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (open) setListId(lists[0]?.id ?? "");
+  }, [open, lists]);
+
+  if (!open) return null;
+
+  function handleConfirm() {
+    if (!listId) {
+      showToast("Wybierz listę docelową", "error");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const result = await generateShoppingListFromPlan({
+          from: defaultFrom,
+          to: defaultTo,
+          listId,
+          skipPantry,
+          consolidate,
+          skipOptional,
+        });
+        const merged = result.mergedCount > 0 ? ` (skonsolidowano ${result.mergedCount})` : "";
+        const skipped =
+          result.skippedFromPantry.length > 0
+            ? ` · ${result.skippedFromPantry.length} pominięto (spiżarnia)`
+            : "";
+        showToast(`Dodano ${result.addedItems.length} pozycji${merged}${skipped}`, "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd generowania", "error");
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:w-[480px] md:rounded border"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          borderColor: "var(--border)",
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3 border-b"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <h3 className="text-base font-semibold flex items-center gap-2" style={{ color: "var(--text-primary)" }}>
+            <ShoppingCart size={16} style={{ color: "var(--accent-orange)" }} />
+            Lista zakupów z planu
+          </h3>
+          <button onClick={onClose} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+            Z aktualnie wybranego tygodnia. Pozycje z różnych przepisów zostaną skonsolidowane.
+          </p>
+
+          {lists.length === 0 ? (
+            <p className="text-sm" style={{ color: "var(--accent-amber)" }}>
+              Brak list zakupów. Utwórz najpierw listę w module Zakupy.
+            </p>
+          ) : (
+            <label className="flex flex-col gap-1 text-sm">
+              <span style={{ color: "var(--text-secondary)" }}>Lista docelowa</span>
+              <select
+                value={listId}
+                onChange={(e) => setListId(e.target.value)}
+                className="px-2 py-1.5 rounded border text-sm"
+                style={{
+                  backgroundColor: "var(--bg-elevated)",
+                  borderColor: "var(--border)",
+                  color: "var(--text-primary)",
+                }}
+              >
+                {lists.map((l) => (
+                  <option key={l.id} value={l.id}>{l.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={skipPantry} onChange={(e) => setSkipPantry(e.target.checked)} />
+            <span style={{ color: "var(--text-primary)" }}>Pomiń to co jest w spiżarni</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={consolidate} onChange={(e) => setConsolidate(e.target.checked)} />
+            <span style={{ color: "var(--text-primary)" }}>Konsoliduj duplikaty (cebula w 3 przepisach → 3 szt)</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={skipOptional} onChange={(e) => setSkipOptional(e.target.checked)} />
+            <span style={{ color: "var(--text-primary)" }}>Pomiń składniki opcjonalne</span>
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-3 border-t" style={{ borderColor: "var(--border)" }}>
+          <button onClick={onClose} className="px-3 py-1.5 rounded text-sm" style={{ color: "var(--text-secondary)" }}>
+            Anuluj
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={pending || lists.length === 0}
+            className="px-3 py-1.5 rounded text-sm disabled:opacity-50"
+            style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+          >
+            {pending ? "Generuję…" : "Dodaj do listy"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/plan/SlotEditorSheet.tsx
+++ b/worldofmag/src/components/kitchen/plan/SlotEditorSheet.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { X, Search, Trash2, CheckCircle2 } from "lucide-react";
+import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
+import { useToast } from "@/components/ui/Toast";
+import {
+  setMealPlanEntry,
+  updateMealPlanEntry,
+  deleteMealPlanEntry,
+  markMealCooked,
+} from "@/actions/mealPlans";
+import type { MealSlot } from "@/types/kitchen";
+import { MEAL_SLOT_LABELS } from "@/types/kitchen";
+import type { MealPlanEntryWithRecipe } from "@/actions/mealPlans";
+import { formatDayLong } from "@/lib/kitchenDate";
+
+export interface RecipePickerItem {
+  id: string;
+  title: string;
+  servings: number;
+  slug: string;
+}
+
+interface SlotEditorSheetProps {
+  open: boolean;
+  onClose: () => void;
+  date: Date;
+  slot: MealSlot;
+  entry?: MealPlanEntryWithRecipe | null;
+  recipes: RecipePickerItem[];
+  teamId?: string | null;
+}
+
+export function SlotEditorSheet({
+  open,
+  onClose,
+  date,
+  slot,
+  entry,
+  recipes,
+  teamId,
+}: SlotEditorSheetProps) {
+  const [query, setQuery] = useState("");
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(entry?.recipeId ?? null);
+  const [customTitle, setCustomTitle] = useState(entry?.customTitle ?? "");
+  const [servings, setServings] = useState(entry?.servings ?? 2);
+  const [pending, startTransition] = useTransition();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (open) {
+      setSelectedRecipeId(entry?.recipeId ?? null);
+      setCustomTitle(entry?.customTitle ?? "");
+      setServings(entry?.servings ?? entry?.recipe?.servings ?? 2);
+      setQuery("");
+    }
+  }, [open, entry]);
+
+  const filteredRecipes = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return recipes.slice(0, 30);
+    return recipes
+      .filter((r) => r.title.toLowerCase().includes(q))
+      .slice(0, 30);
+  }, [recipes, query]);
+
+  if (!open) return null;
+
+  function handleSelectRecipe(id: string, defaultServings: number) {
+    setSelectedRecipeId(id);
+    setCustomTitle("");
+    setServings(defaultServings);
+  }
+
+  function handleSave() {
+    if (!selectedRecipeId && !customTitle.trim()) {
+      showToast("Wybierz przepis lub wpisz tytuł", "error");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        if (entry) {
+          await updateMealPlanEntry(entry.id, {
+            recipeId: selectedRecipeId,
+            customTitle: selectedRecipeId ? null : customTitle.trim() || null,
+            servings,
+          });
+        } else {
+          await setMealPlanEntry({
+            date,
+            slot,
+            recipeId: selectedRecipeId,
+            customTitle: selectedRecipeId ? null : customTitle.trim() || null,
+            servings,
+            teamId: teamId ?? null,
+          });
+        }
+        showToast(entry ? "Wpis zaktualizowany" : "Wpis dodany", "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd zapisu", "error");
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!entry) return;
+    if (!confirm("Usunąć ten wpis z planu?")) return;
+    startTransition(async () => {
+      try {
+        await deleteMealPlanEntry(entry.id);
+        showToast("Usunięto z planu", "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  function handleCooked() {
+    if (!entry) return;
+    startTransition(async () => {
+      try {
+        await markMealCooked(entry.id);
+        showToast("Zaznaczono jako ugotowane", "success");
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:w-[500px] md:rounded border max-h-[90vh] overflow-y-auto"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          borderColor: "var(--border)",
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3 border-b"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <div>
+            <h3 className="text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+              {MEAL_SLOT_LABELS[slot]}
+            </h3>
+            <p className="text-xs" style={{ color: "var(--text-muted)" }}>{formatDayLong(date)}</p>
+          </div>
+          <button onClick={onClose} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          <div
+            className="flex items-center gap-2 px-3 py-2 rounded border"
+            style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-elevated)" }}
+          >
+            <Search size={14} style={{ color: "var(--text-muted)" }} />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Wybierz przepis…"
+              className="flex-1 bg-transparent border-none outline-none text-sm"
+              style={{ color: "var(--text-primary)" }}
+            />
+          </div>
+
+          <div
+            className="flex flex-col gap-0.5 max-h-56 overflow-y-auto border rounded"
+            style={{ borderColor: "var(--border)" }}
+          >
+            {filteredRecipes.length === 0 ? (
+              <div className="px-3 py-3 text-sm" style={{ color: "var(--text-muted)" }}>
+                Brak pasujących przepisów.
+              </div>
+            ) : (
+              filteredRecipes.map((r) => {
+                const isSelected = selectedRecipeId === r.id;
+                return (
+                  <button
+                    key={r.id}
+                    type="button"
+                    onClick={() => handleSelectRecipe(r.id, r.servings)}
+                    className="flex items-center justify-between px-3 py-2 text-sm text-left"
+                    style={{
+                      backgroundColor: isSelected ? "var(--bg-elevated)" : "transparent",
+                      color: isSelected ? "var(--accent-orange)" : "var(--text-primary)",
+                    }}
+                  >
+                    <span>{r.title}</span>
+                    <span className="text-xs" style={{ color: "var(--text-muted)" }}>{r.servings}p</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-xs" style={{ color: "var(--text-muted)" }}>lub własny tytuł:</span>
+            <input
+              type="text"
+              value={customTitle}
+              onChange={(e) => {
+                setCustomTitle(e.target.value);
+                if (e.target.value.trim()) setSelectedRecipeId(null);
+              }}
+              placeholder="np. obiad u rodziców"
+              className="flex-1 px-2 py-1 rounded border text-sm"
+              style={{
+                backgroundColor: "var(--bg-elevated)",
+                borderColor: "var(--border)",
+                color: "var(--text-primary)",
+              }}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Porcje</span>
+            <ServingSelector value={servings} onChange={setServings} />
+          </div>
+        </div>
+
+        <div
+          className="flex items-center justify-between gap-2 px-4 py-3 border-t"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <div className="flex items-center gap-1">
+            {entry ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleCooked}
+                  disabled={pending || entry.status === "COOKED"}
+                  className="inline-flex items-center gap-1 px-2 py-1.5 rounded text-xs disabled:opacity-50"
+                  style={{ color: "var(--accent-green)" }}
+                >
+                  <CheckCircle2 size={14} /> Ugotowane
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={pending}
+                  className="inline-flex items-center gap-1 px-2 py-1.5 rounded text-xs disabled:opacity-50"
+                  style={{ color: "var(--accent-red)" }}
+                >
+                  <Trash2 size={14} /> Usuń
+                </button>
+              </>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={onClose} className="px-3 py-1.5 rounded text-sm" style={{ color: "var(--text-secondary)" }}>
+              Anuluj
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={pending}
+              className="px-3 py-1.5 rounded text-sm disabled:opacity-50"
+              style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+            >
+              {pending ? "Zapisuję…" : "Zapisz"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/CookMode.tsx
+++ b/worldofmag/src/components/kitchen/recipes/CookMode.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { X, ChevronLeft, ChevronRight, Play, Pause, Square, List, CheckCircle2 } from "lucide-react";
+import { useToast } from "@/components/ui/Toast";
+import { markRecipeCooked } from "@/actions/recipes";
+import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
+import type { RecipeFull } from "@/types/kitchen";
+
+interface CookModeProps {
+  recipe: RecipeFull;
+}
+
+interface TimerState {
+  stepId: string;
+  remaining: number; // seconds
+  running: boolean;
+}
+
+function scaleQty(qty: number | null, factor: number): number | null {
+  if (qty == null) return null;
+  return Math.round(qty * factor * 100) / 100;
+}
+
+function formatMmSs(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+}
+
+export function CookMode({ recipe }: CookModeProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [stepIdx, setStepIdx] = useState(0);
+  const [ingredientsOpen, setIngredientsOpen] = useState(false);
+  const [completedDialog, setCompletedDialog] = useState(false);
+  const [completedServings, setCompletedServings] = useState(recipe.servings);
+  const [pendingCook, startCook] = useTransition();
+  const [timers, setTimers] = useState<TimerState[]>(() =>
+    recipe.steps
+      .filter((s) => s.durationMin != null)
+      .map((s) => ({ stepId: s.id, remaining: (s.durationMin ?? 0) * 60, running: false }))
+  );
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  const steps = recipe.steps;
+  const currentStep = steps[stepIdx];
+
+  // Wake lock — keep screen on while cook mode is open
+  useEffect(() => {
+    let cancelled = false;
+    async function acquire() {
+      try {
+        if ("wakeLock" in navigator) {
+          const lock = await (navigator as Navigator & {
+            wakeLock: { request: (t: "screen") => Promise<WakeLockSentinel> };
+          }).wakeLock.request("screen");
+          if (cancelled) {
+            await lock.release();
+            return;
+          }
+          wakeLockRef.current = lock;
+        }
+      } catch {
+        // ignore — not supported in this browser
+      }
+    }
+    acquire();
+    return () => {
+      cancelled = true;
+      wakeLockRef.current?.release().catch(() => {});
+      wakeLockRef.current = null;
+    };
+  }, []);
+
+  // Timer ticker
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimers((prev) => {
+        let changed = false;
+        const next = prev.map((t) => {
+          if (!t.running) return t;
+          if (t.remaining <= 0) return t;
+          const remaining = t.remaining - 1;
+          changed = true;
+          if (remaining === 0) {
+            // beep + vibrate
+            try {
+              if ("vibrate" in navigator) navigator.vibrate([200, 100, 200]);
+            } catch {
+              /* noop */
+            }
+          }
+          return { ...t, remaining, running: remaining > 0 };
+        });
+        return changed ? next : prev;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, typeof recipe.ingredients>();
+    for (const ing of recipe.ingredients) {
+      const key = ing.groupName ?? "";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(ing);
+    }
+    return Array.from(groups.entries());
+  }, [recipe.ingredients]);
+
+  function next() {
+    if (stepIdx < steps.length - 1) setStepIdx((i) => i + 1);
+    else setCompletedDialog(true);
+  }
+  function prev() {
+    if (stepIdx > 0) setStepIdx((i) => i - 1);
+  }
+
+  function handleTimerToggle(stepId: string) {
+    setTimers((prev) =>
+      prev.map((t) => (t.stepId === stepId ? { ...t, running: !t.running } : t))
+    );
+  }
+  function handleTimerReset(stepId: string, defaultMin: number) {
+    setTimers((prev) =>
+      prev.map((t) =>
+        t.stepId === stepId ? { ...t, remaining: defaultMin * 60, running: false } : t
+      )
+    );
+  }
+
+  function handleExit() {
+    router.push(`/kitchen/recipes/${recipe.slug}`);
+  }
+
+  function handleConfirmCooked() {
+    startCook(async () => {
+      try {
+        await markRecipeCooked(recipe.id, completedServings);
+        showToast("Zapisano. Smacznego!", "success");
+        router.push(`/kitchen/recipes/${recipe.slug}`);
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  // Keyboard navigation
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (completedDialog || ingredientsOpen) return;
+      if (e.key === "ArrowRight" || e.key === " ") {
+        e.preventDefault();
+        next();
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        prev();
+      } else if (e.key === "Escape") {
+        handleExit();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stepIdx, completedDialog, ingredientsOpen]);
+
+  if (steps.length === 0) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex flex-col items-center justify-center px-6"
+        style={{ backgroundColor: "var(--kitchen-cook-bg, #050505)", color: "#fff" }}
+      >
+        <p className="text-lg mb-4">Ten przepis nie ma jeszcze kroków.</p>
+        <button
+          onClick={handleExit}
+          className="px-4 py-2 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          Wyjdź
+        </button>
+      </div>
+    );
+  }
+
+  const activeTimer = timers.find((t) => t.stepId === currentStep?.id);
+  const runningTimers = timers.filter((t) => t.running && t.remaining > 0);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col"
+      style={{ backgroundColor: "var(--kitchen-cook-bg, #050505)", color: "#fff" }}
+    >
+      {/* Top bar */}
+      <header
+        className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b"
+        style={{ borderColor: "#222" }}
+      >
+        <button
+          onClick={handleExit}
+          className="inline-flex items-center gap-1.5 text-sm"
+          style={{ color: "#999" }}
+        >
+          <X size={16} /> Wyjdź
+        </button>
+        <div className="text-xs" style={{ color: "#999" }}>
+          {recipe.title} · Krok {stepIdx + 1} / {steps.length}
+        </div>
+        <button
+          onClick={() => setIngredientsOpen(true)}
+          className="inline-flex items-center gap-1.5 text-sm"
+          style={{ color: "#999" }}
+          aria-label="Pokaż składniki"
+        >
+          <List size={16} />
+        </button>
+      </header>
+
+      {/* Step content */}
+      <main className="flex-1 relative overflow-hidden">
+        {/* Tap zones (mobile-friendly) */}
+        <button
+          type="button"
+          onClick={prev}
+          className="absolute inset-y-0 left-0 w-1/3 z-10"
+          style={{ background: "transparent" }}
+          aria-label="Poprzedni krok"
+        />
+        <button
+          type="button"
+          onClick={next}
+          className="absolute inset-y-0 right-0 w-1/3 z-10"
+          style={{ background: "transparent" }}
+          aria-label="Następny krok"
+        />
+
+        <div
+          aria-live="polite"
+          className="h-full flex flex-col items-center justify-center px-6 md:px-12 text-center"
+        >
+          <p
+            className="leading-snug max-w-3xl"
+            style={{
+              fontSize: "clamp(22px, 4vw, 36px)",
+              color: "#fff",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {currentStep?.text}
+          </p>
+          {currentStep?.temperature ? (
+            <p className="mt-4 text-base" style={{ color: "var(--accent-amber)" }}>
+              🌡 {currentStep.temperature}
+            </p>
+          ) : null}
+
+          {activeTimer ? (
+            <div className="mt-6 flex flex-col items-center gap-3">
+              <div
+                className="text-4xl md:text-6xl tabular-nums"
+                style={{
+                  color: activeTimer.remaining === 0 ? "var(--accent-green)" : "#fff",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {formatMmSs(activeTimer.remaining)}
+              </div>
+              <div className="flex items-center gap-2 z-20 relative">
+                <button
+                  type="button"
+                  onClick={() => handleTimerToggle(activeTimer.stepId)}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm"
+                  style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+                >
+                  {activeTimer.running ? <Pause size={16} /> : <Play size={16} />}
+                  {activeTimer.running ? "Pauza" : "Start"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleTimerReset(activeTimer.stepId, currentStep?.durationMin ?? 0)}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm border"
+                  style={{ borderColor: "#333", color: "#fff" }}
+                >
+                  <Square size={14} /> Reset
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Floating running timers */}
+        {runningTimers.length > 0 ? (
+          <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center gap-1">
+            {runningTimers.map((t) => {
+              const step = recipe.steps.find((s) => s.id === t.stepId);
+              const idx = recipe.steps.findIndex((s) => s.id === t.stepId) + 1;
+              return (
+                <div
+                  key={t.stepId}
+                  className="text-xs px-2 py-1 rounded-full tabular-nums"
+                  style={{ backgroundColor: "rgba(255, 138, 61, 0.16)", color: "var(--accent-orange)" }}
+                  title={step?.text}
+                >
+                  Krok {idx}: {formatMmSs(t.remaining)}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </main>
+
+      {/* Bottom bar with prev/next + progress */}
+      <footer
+        className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-t z-20"
+        style={{ borderColor: "#222" }}
+      >
+        <button
+          type="button"
+          onClick={prev}
+          disabled={stepIdx === 0}
+          className="inline-flex items-center gap-1 px-3 py-2 rounded text-sm disabled:opacity-30"
+          style={{ color: "#fff" }}
+        >
+          <ChevronLeft size={16} /> Poprzedni
+        </button>
+        <div className="flex items-center gap-1">
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              className="rounded-full"
+              style={{
+                width: 6,
+                height: 6,
+                backgroundColor: i === stepIdx ? "var(--accent-orange)" : i < stepIdx ? "var(--accent-green)" : "#333",
+              }}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={next}
+          className="inline-flex items-center gap-1 px-3 py-2 rounded text-sm"
+          style={{
+            color: stepIdx === steps.length - 1 ? "#0d0d0d" : "#fff",
+            backgroundColor: stepIdx === steps.length - 1 ? "var(--accent-green)" : "transparent",
+          }}
+        >
+          {stepIdx === steps.length - 1 ? "Skończone" : "Następny"} <ChevronRight size={16} />
+        </button>
+      </footer>
+
+      {/* Ingredients sheet */}
+      {ingredientsOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+          style={{ backgroundColor: "rgba(0,0,0,0.7)" }}
+          onClick={() => setIngredientsOpen(false)}
+        >
+          <div
+            className="w-full md:w-[460px] md:rounded border max-h-[80vh] overflow-y-auto"
+            style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div
+              className="flex items-center justify-between px-4 py-3 border-b"
+              style={{ borderColor: "var(--border)" }}
+            >
+              <h3 className="text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+                Składniki ({recipe.servings} porcji)
+              </h3>
+              <button onClick={() => setIngredientsOpen(false)} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+                <X size={18} />
+              </button>
+            </div>
+            <div className="px-4 py-3 flex flex-col gap-3">
+              {grouped.map(([group, items]) => (
+                <div key={group}>
+                  {group ? (
+                    <h4 className="text-xs font-semibold uppercase mb-1" style={{ color: "var(--text-secondary)" }}>
+                      {group}
+                    </h4>
+                  ) : null}
+                  <ul className="flex flex-col gap-1">
+                    {items.map((ing) => {
+                      const q = scaleQty(ing.quantity, 1);
+                      return (
+                        <li key={ing.id} className="text-sm" style={{ color: "var(--text-primary)" }}>
+                          {q != null ? <span className="tabular-nums">{q}</span> : null}
+                          {q != null && ing.unit ? <span>{` ${ing.unit}`}</span> : null}
+                          {q != null ? " " : ""}
+                          {ing.name}
+                          {ing.note ? <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>— {ing.note}</span> : null}
+                          {ing.isOptional ? <span className="ml-1 text-[10px]" style={{ color: "var(--text-muted)" }}>(opc.)</span> : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Mark cooked dialog */}
+      {completedDialog ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4"
+          style={{ backgroundColor: "rgba(0,0,0,0.7)" }}
+        >
+          <div
+            className="w-full max-w-sm rounded border p-5"
+            style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)" }}
+          >
+            <h3 className="text-lg font-semibold mb-1" style={{ color: "var(--text-primary)" }}>
+              Ugotowane!
+            </h3>
+            <p className="text-sm mb-4" style={{ color: "var(--text-secondary)" }}>
+              {recipe.title}
+            </p>
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Ile porcji wyszło?</span>
+              <ServingSelector value={completedServings} onChange={setCompletedServings} />
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                onClick={() => setCompletedDialog(false)}
+                className="px-3 py-1.5 rounded text-sm"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Wróć
+              </button>
+              <button
+                onClick={handleConfirmCooked}
+                disabled={pendingCook}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm disabled:opacity-50"
+                style={{ backgroundColor: "var(--accent-green)", color: "#0d0d0d" }}
+              >
+                <CheckCircle2 size={14} /> {pendingCook ? "Zapisuję…" : "Zapisz"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/ImportFromUrlDialog.tsx
+++ b/worldofmag/src/components/kitchen/recipes/ImportFromUrlDialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { X, Globe } from "lucide-react";
+import { llm } from "@/lib/llm-client";
+import { useToast } from "@/components/ui/Toast";
+import { createRecipe } from "@/actions/recipes";
+import type { CreateRecipeInput, MealType, Difficulty } from "@/types/kitchen";
+
+interface ImportFromUrlDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const VALID_MEAL_TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack", "dessert"];
+
+export function ImportFromUrlDialog({ open, onClose }: ImportFromUrlDialogProps) {
+  const router = useRouter();
+  const [url, setUrl] = useState("");
+  const [pending, setPending] = useState(false);
+  const { showToast } = useToast();
+
+  if (!open) return null;
+
+  async function handleImport() {
+    if (!url.trim()) {
+      showToast("Wpisz URL", "error");
+      return;
+    }
+    setPending(true);
+    try {
+      const res = await llm.kitchen.importFromUrl(url.trim());
+      if (res.error || !res.recipe) {
+        showToast(res.error ?? "Nie udało się zaimportować", "error");
+        return;
+      }
+      const r = res.recipe;
+      const payload: CreateRecipeInput = {
+        title: r.title,
+        description: r.description,
+        servings: r.servings ?? 2,
+        prepMinutes: r.prepMinutes,
+        cookMinutes: r.cookMinutes,
+        coverImageUrl: r.coverImageUrl,
+        cuisine: r.cuisine,
+        mealType: r.mealType && (VALID_MEAL_TYPES as string[]).includes(r.mealType)
+          ? (r.mealType as MealType)
+          : null,
+        difficulty: "easy" as Difficulty,
+        ingredients: r.ingredients.map((ing, idx) => ({
+          name: ing.name,
+          quantity: ing.quantity ?? null,
+          unit: ing.unit ?? null,
+          note: ing.note ?? null,
+          isOptional: ing.isOptional ?? false,
+          order: idx,
+        })),
+        steps: r.steps.map((s, idx) => ({ text: s.text, order: idx })),
+      };
+      const created = await createRecipe(payload);
+      showToast("Zaimportowano przepis", "success");
+      router.push(`/kitchen/recipes/${created.slug}`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Błąd importu", "error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:w-[480px] md:rounded border"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          borderColor: "var(--border)",
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "var(--border)" }}>
+          <h3 className="text-base font-semibold flex items-center gap-2" style={{ color: "var(--text-primary)" }}>
+            <Globe size={16} style={{ color: "var(--accent-purple)" }} />
+            Import z URL
+          </h3>
+          <button onClick={onClose} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+            Wklej link do przepisu. AI pobierze stronę i wyciągnie składniki + kroki (najpierw spróbuje schema.org JSON-LD, potem LLM).
+          </p>
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://…"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleImport();
+            }}
+            className="w-full px-3 py-2 rounded border text-sm"
+            style={{
+              backgroundColor: "var(--bg-elevated)",
+              borderColor: "var(--border)",
+              color: "var(--text-primary)",
+            }}
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-3 border-t" style={{ borderColor: "var(--border)" }}>
+          <button onClick={onClose} className="px-3 py-1.5 rounded text-sm" style={{ color: "var(--text-secondary)" }}>
+            Anuluj
+          </button>
+          <button
+            onClick={handleImport}
+            disabled={pending}
+            className="px-3 py-1.5 rounded text-sm disabled:opacity-50"
+            style={{ backgroundColor: "var(--accent-purple)", color: "#fff" }}
+          >
+            {pending ? "Importuję…" : "Importuj"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/RecipeCard.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeCard.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { Clock, Users, ChefHat, Star } from "lucide-react";
+import type { RecipeListItem } from "@/types/kitchen";
+import { DIFFICULTY_LABELS } from "@/types/kitchen";
+
+interface RecipeCardProps {
+  recipe: RecipeListItem;
+  highlightQuery?: string;
+}
+
+function totalMinutes(r: RecipeListItem): number | null {
+  const m = (r.prepMinutes ?? 0) + (r.cookMinutes ?? 0);
+  return m > 0 ? m : null;
+}
+
+function formatLastCooked(date: Date | null): string | null {
+  if (!date) return null;
+  const d = new Date(date);
+  const diff = Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));
+  if (diff === 0) return "dziś";
+  if (diff === 1) return "wczoraj";
+  if (diff < 7) return `${diff} dni temu`;
+  if (diff < 30) return `${Math.floor(diff / 7)} tyg. temu`;
+  return d.toLocaleDateString("pl-PL");
+}
+
+export function RecipeCard({ recipe }: RecipeCardProps) {
+  const total = totalMinutes(recipe);
+  const lastCooked = formatLastCooked(recipe.lastCookedAt);
+  const visibleTags = recipe.tags.slice(0, 3);
+  const extraTags = recipe.tags.length - visibleTags.length;
+
+  return (
+    <Link
+      href={`/kitchen/recipes/${recipe.slug}`}
+      className="flex flex-col rounded overflow-hidden border transition-colors"
+      style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+    >
+      <div
+        className="relative w-full"
+        style={{
+          aspectRatio: "16 / 9",
+          backgroundColor: "var(--bg-elevated)",
+          backgroundImage: recipe.coverImageUrl ? `url(${recipe.coverImageUrl})` : undefined,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      >
+        {!recipe.coverImageUrl && (
+          <div
+            className="absolute inset-0 flex items-center justify-center"
+            style={{ color: "var(--text-muted)" }}
+          >
+            <ChefHat size={32} />
+          </div>
+        )}
+      </div>
+      <div className="p-3 flex flex-col gap-2">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-medium leading-snug" style={{ color: "var(--text-primary)" }}>
+            {recipe.title}
+          </h3>
+          {recipe.rating != null && recipe.rating > 0 ? (
+            <span className="flex items-center gap-0.5 text-xs flex-shrink-0" style={{ color: "var(--accent-amber)" }}>
+              <Star size={11} fill="currentColor" />
+              {recipe.rating.toFixed(1)}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs" style={{ color: "var(--text-muted)" }}>
+          {total != null ? (
+            <span className="inline-flex items-center gap-1"><Clock size={11} />{total} min</span>
+          ) : null}
+          <span className="inline-flex items-center gap-1"><Users size={11} />{recipe.servings}p</span>
+          {recipe.difficulty ? (
+            <span>{DIFFICULTY_LABELS[recipe.difficulty as keyof typeof DIFFICULTY_LABELS] ?? recipe.difficulty}</span>
+          ) : null}
+          {lastCooked ? <span>· ost. {lastCooked}</span> : null}
+        </div>
+        {visibleTags.length > 0 || recipe.cuisine ? (
+          <div className="flex flex-wrap gap-1">
+            {recipe.cuisine ? (
+              <span
+                className="text-[10px] px-2 py-0.5 rounded"
+                style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+              >
+                {recipe.cuisine}
+              </span>
+            ) : null}
+            {visibleTags.map(({ tag }) => (
+              <span
+                key={tag.id}
+                className="text-[10px] px-2 py-0.5 rounded"
+                style={{ backgroundColor: tag.color ?? "var(--bg-elevated)", color: "var(--text-secondary)" }}
+              >
+                {tag.name}
+              </span>
+            ))}
+            {extraTags > 0 ? (
+              <span className="text-[10px] px-2 py-0.5 rounded" style={{ color: "var(--text-muted)" }}>
+                +{extraTags}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </Link>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/RecipeEditor.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeEditor.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2, Save, ArrowLeft } from "lucide-react";
+import { Plus, Trash2, Save, ArrowLeft, Sparkles } from "lucide-react";
 import { parseQuantity } from "@/lib/parseQuantity";
+import { llm } from "@/lib/llm-client";
 import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
 import { useToast } from "@/components/ui/Toast";
 import { createRecipe, updateRecipe } from "@/actions/recipes";
@@ -20,6 +21,7 @@ import { MEAL_TYPE_LABELS, DIFFICULTY_LABELS } from "@/types/kitchen";
 interface RecipeEditorProps {
   recipe?: RecipeFull;
   cookbooks: Array<{ id: string; name: string; emoji: string }>;
+  hasAI?: boolean;
 }
 
 interface IngredientRow extends IngredientInput {
@@ -34,10 +36,13 @@ function makeKey(): string {
   return Math.random().toString(36).slice(2, 10);
 }
 
-export function RecipeEditor({ recipe, cookbooks }: RecipeEditorProps) {
+export function RecipeEditor({ recipe, cookbooks, hasAI }: RecipeEditorProps) {
   const router = useRouter();
   const { showToast } = useToast();
   const [pending, startTransition] = useTransition();
+  const [aiOpen, setAiOpen] = useState(false);
+  const [aiText, setAiText] = useState("");
+  const [aiPending, setAiPending] = useState(false);
 
   const [title, setTitle] = useState(recipe?.title ?? "");
   const [description, setDescription] = useState(recipe?.description ?? "");
@@ -95,6 +100,46 @@ export function RecipeEditor({ recipe, cookbooks }: RecipeEditorProps) {
       quantity: parsed.quantity ?? null,
       unit: parsed.unit ?? null,
     });
+  }
+
+  async function handleAIParse() {
+    if (!aiText.trim()) {
+      showToast("Wklej tekst do parsowania", "error");
+      return;
+    }
+    setAiPending(true);
+    try {
+      const res = await llm.kitchen.parseIngredients(aiText.trim());
+      if (res.error) {
+        showToast(res.error, "error");
+        return;
+      }
+      const parsed = res.ingredients ?? [];
+      if (parsed.length === 0) {
+        showToast("AI nie znalazło składników", "info");
+        return;
+      }
+      setIngredients((prev) => {
+        // jeśli aktualne pole pierwszy ingredient jest puste — zastąp; inaczej dopisz
+        const isEmptySingle = prev.length === 1 && !prev[0].name.trim();
+        const merged: IngredientRow[] = parsed.map((p) => ({
+          _key: makeKey(),
+          name: p.name,
+          quantity: p.quantity,
+          unit: p.unit,
+          note: p.note,
+          isOptional: p.isOptional,
+        }));
+        return isEmptySingle ? merged : [...prev, ...merged];
+      });
+      showToast(`AI dodało ${parsed.length} składników`, "success");
+      setAiOpen(false);
+      setAiText("");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Błąd AI", "error");
+    } finally {
+      setAiPending(false);
+    }
   }
 
   function addStep() {
@@ -312,15 +357,65 @@ export function RecipeEditor({ recipe, cookbooks }: RecipeEditorProps) {
             <h2 className="text-sm font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
               Składniki
             </h2>
-            <button
-              type="button"
-              onClick={addIngredient}
-              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded"
-              style={{ color: "var(--accent-orange)" }}
-            >
-              <Plus size={12} /> Dodaj
-            </button>
+            <div className="flex items-center gap-1">
+              {hasAI ? (
+                <button
+                  type="button"
+                  onClick={() => setAiOpen((v) => !v)}
+                  className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded"
+                  style={{ color: "var(--accent-purple)" }}
+                >
+                  <Sparkles size={12} /> Wklej AI
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={addIngredient}
+                className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded"
+                style={{ color: "var(--accent-orange)" }}
+              >
+                <Plus size={12} /> Dodaj
+              </button>
+            </div>
           </div>
+
+          {aiOpen ? (
+            <div
+              className="mb-2 p-2 rounded border"
+              style={{ borderColor: "var(--accent-purple)", backgroundColor: "var(--bg-surface)" }}
+            >
+              <p className="text-xs mb-1" style={{ color: "var(--text-muted)" }}>
+                Wklej blok tekstu — AI rozpozna składniki.
+              </p>
+              <textarea
+                value={aiText}
+                onChange={(e) => setAiText(e.target.value)}
+                rows={5}
+                placeholder={"400 g mąki\n2 jajka\nszczypta soli"}
+                className="w-full px-2 py-1.5 rounded border text-xs"
+                style={inputStyle}
+              />
+              <div className="flex items-center justify-end gap-1 mt-1.5">
+                <button
+                  type="button"
+                  onClick={() => setAiOpen(false)}
+                  className="px-2 py-1 rounded text-xs"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  Anuluj
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAIParse}
+                  disabled={aiPending}
+                  className="px-2 py-1 rounded text-xs disabled:opacity-50"
+                  style={{ backgroundColor: "var(--accent-purple)", color: "#fff" }}
+                >
+                  {aiPending ? "Parsuję…" : "Parsuj"}
+                </button>
+              </div>
+            </div>
+          ) : null}
           <div className="flex flex-col gap-1.5">
             {ingredients.map((ing, idx) => (
               <div

--- a/worldofmag/src/components/kitchen/recipes/RecipeEditor.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeEditor.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Trash2, Save, ArrowLeft } from "lucide-react";
+import { parseQuantity } from "@/lib/parseQuantity";
+import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
+import { useToast } from "@/components/ui/Toast";
+import { createRecipe, updateRecipe } from "@/actions/recipes";
+import type {
+  RecipeFull,
+  CreateRecipeInput,
+  IngredientInput,
+  StepInput,
+  Difficulty,
+  MealType,
+} from "@/types/kitchen";
+import { MEAL_TYPE_LABELS, DIFFICULTY_LABELS } from "@/types/kitchen";
+
+interface RecipeEditorProps {
+  recipe?: RecipeFull;
+  cookbooks: Array<{ id: string; name: string; emoji: string }>;
+}
+
+interface IngredientRow extends IngredientInput {
+  _key: string;
+}
+
+interface StepRow extends StepInput {
+  _key: string;
+}
+
+function makeKey(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export function RecipeEditor({ recipe, cookbooks }: RecipeEditorProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [pending, startTransition] = useTransition();
+
+  const [title, setTitle] = useState(recipe?.title ?? "");
+  const [description, setDescription] = useState(recipe?.description ?? "");
+  const [coverImageUrl, setCoverImageUrl] = useState(recipe?.coverImageUrl ?? "");
+  const [servings, setServings] = useState(recipe?.servings ?? 2);
+  const [prepMinutes, setPrepMinutes] = useState<string>(recipe?.prepMinutes?.toString() ?? "");
+  const [cookMinutes, setCookMinutes] = useState<string>(recipe?.cookMinutes?.toString() ?? "");
+  const [difficulty, setDifficulty] = useState<Difficulty>((recipe?.difficulty as Difficulty) ?? "easy");
+  const [cuisine, setCuisine] = useState(recipe?.cuisine ?? "");
+  const [mealType, setMealType] = useState<MealType | "">((recipe?.mealType as MealType) ?? "");
+  const [cookbookId, setCookbookId] = useState<string>(recipe?.cookbookId ?? "");
+  const [notes, setNotes] = useState(recipe?.notes ?? "");
+
+  const [ingredients, setIngredients] = useState<IngredientRow[]>(
+    recipe?.ingredients.map((ing) => ({
+      _key: ing.id,
+      name: ing.name,
+      productId: ing.productId,
+      quantity: ing.quantity,
+      unit: ing.unit,
+      groupName: ing.groupName,
+      note: ing.note,
+      isOptional: ing.isOptional,
+      order: ing.order,
+    })) ?? [{ _key: makeKey(), name: "" }]
+  );
+
+  const [steps, setSteps] = useState<StepRow[]>(
+    recipe?.steps.map((s) => ({
+      _key: s.id,
+      text: s.text,
+      order: s.order,
+      durationMin: s.durationMin,
+      temperature: s.temperature,
+      imageUrl: s.imageUrl,
+    })) ?? [{ _key: makeKey(), text: "" }]
+  );
+
+  function addIngredient() {
+    setIngredients((prev) => [...prev, { _key: makeKey(), name: "" }]);
+  }
+
+  function updateIngredientLocal(key: string, patch: Partial<IngredientRow>) {
+    setIngredients((prev) => prev.map((ing) => (ing._key === key ? { ...ing, ...patch } : ing)));
+  }
+
+  function removeIngredient(key: string) {
+    setIngredients((prev) => prev.filter((ing) => ing._key !== key));
+  }
+
+  function handleIngredientSmartPaste(key: string, raw: string) {
+    const parsed = parseQuantity(raw);
+    updateIngredientLocal(key, {
+      name: parsed.name,
+      quantity: parsed.quantity ?? null,
+      unit: parsed.unit ?? null,
+    });
+  }
+
+  function addStep() {
+    setSteps((prev) => [...prev, { _key: makeKey(), text: "" }]);
+  }
+
+  function updateStepLocal(key: string, patch: Partial<StepRow>) {
+    setSteps((prev) => prev.map((s) => (s._key === key ? { ...s, ...patch } : s)));
+  }
+
+  function removeStep(key: string) {
+    setSteps((prev) => prev.filter((s) => s._key !== key));
+  }
+
+  function handleSave() {
+    if (!title.trim()) {
+      showToast("Tytuł jest wymagany", "error");
+      return;
+    }
+    const payload: CreateRecipeInput = {
+      title: title.trim(),
+      description: description.trim() || null,
+      coverImageUrl: coverImageUrl.trim() || null,
+      servings,
+      prepMinutes: prepMinutes ? Number(prepMinutes) : null,
+      cookMinutes: cookMinutes ? Number(cookMinutes) : null,
+      difficulty,
+      cuisine: cuisine.trim() || null,
+      mealType: mealType || null,
+      cookbookId: cookbookId || null,
+      notes,
+      ingredients: ingredients
+        .filter((ing) => ing.name.trim())
+        .map((ing, idx) => ({
+          name: ing.name.trim(),
+          productId: ing.productId ?? null,
+          quantity: ing.quantity ?? null,
+          unit: ing.unit ?? null,
+          groupName: ing.groupName ?? null,
+          note: ing.note ?? null,
+          isOptional: ing.isOptional ?? false,
+          order: idx,
+        })),
+      steps: steps
+        .filter((s) => s.text.trim())
+        .map((s, idx) => ({
+          text: s.text,
+          order: idx,
+          durationMin: s.durationMin ?? null,
+          temperature: s.temperature ?? null,
+        })),
+    };
+
+    startTransition(async () => {
+      try {
+        if (recipe) {
+          await updateRecipe(recipe.id, payload);
+          showToast("Przepis zapisany", "success");
+          router.push(`/kitchen/recipes/${recipe.slug}`);
+        } else {
+          const created = await createRecipe(payload);
+          showToast("Przepis utworzony", "success");
+          router.push(`/kitchen/recipes/${created.slug}`);
+        }
+        router.refresh();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd zapisu", "error");
+      }
+    });
+  }
+
+  const isEdit = !!recipe;
+
+  return (
+    <div className="px-4 md:px-6 py-4 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="inline-flex items-center gap-1 text-sm"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft size={14} /> Anuluj
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={pending}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm disabled:opacity-50"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Save size={14} /> {pending ? "Zapisuję…" : "Zapisz"}
+        </button>
+      </div>
+
+      <h1 className="text-lg font-semibold mb-3" style={{ color: "var(--text-primary)" }}>
+        {isEdit ? "Edycja przepisu" : "Nowy przepis"}
+      </h1>
+
+      <div className="flex flex-col gap-3">
+        <Field label="Tytuł">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="np. Spaghetti Carbonara"
+            autoFocus
+            className="w-full px-3 py-2 rounded border text-sm"
+            style={inputStyle}
+          />
+        </Field>
+
+        <Field label="Krótki opis (opcjonalny)">
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 rounded border text-sm resize-y"
+            style={inputStyle}
+          />
+        </Field>
+
+        <Field label="URL zdjęcia (opcjonalny)">
+          <input
+            type="url"
+            value={coverImageUrl}
+            onChange={(e) => setCoverImageUrl(e.target.value)}
+            placeholder="https://…"
+            className="w-full px-3 py-2 rounded border text-sm"
+            style={inputStyle}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          <Field label="Czas przyg. (min)">
+            <input
+              type="number"
+              min={0}
+              value={prepMinutes}
+              onChange={(e) => setPrepMinutes(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            />
+          </Field>
+          <Field label="Czas gotowania (min)">
+            <input
+              type="number"
+              min={0}
+              value={cookMinutes}
+              onChange={(e) => setCookMinutes(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            />
+          </Field>
+          <Field label="Porcje">
+            <div className="flex items-center h-9">
+              <ServingSelector value={servings} onChange={setServings} />
+            </div>
+          </Field>
+          <Field label="Trudność">
+            <select
+              value={difficulty}
+              onChange={(e) => setDifficulty(e.target.value as Difficulty)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            >
+              {(Object.keys(DIFFICULTY_LABELS) as Difficulty[]).map((d) => (
+                <option key={d} value={d}>{DIFFICULTY_LABELS[d]}</option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+          <Field label="Kuchnia">
+            <input
+              type="text"
+              value={cuisine}
+              onChange={(e) => setCuisine(e.target.value)}
+              placeholder="np. włoska"
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            />
+          </Field>
+          <Field label="Posiłek">
+            <select
+              value={mealType}
+              onChange={(e) => setMealType(e.target.value as MealType | "")}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            >
+              <option value="">—</option>
+              {(Object.keys(MEAL_TYPE_LABELS) as MealType[]).map((mt) => (
+                <option key={mt} value={mt}>{MEAL_TYPE_LABELS[mt]}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Książka kucharska">
+            <select
+              value={cookbookId}
+              onChange={(e) => setCookbookId(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border text-sm"
+              style={inputStyle}
+            >
+              <option value="">— brak —</option>
+              {cookbooks.map((cb) => (
+                <option key={cb.id} value={cb.id}>{cb.emoji} {cb.name}</option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+              Składniki
+            </h2>
+            <button
+              type="button"
+              onClick={addIngredient}
+              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded"
+              style={{ color: "var(--accent-orange)" }}
+            >
+              <Plus size={12} /> Dodaj
+            </button>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {ingredients.map((ing, idx) => (
+              <div
+                key={ing._key}
+                className="flex items-center gap-1.5 p-1.5 rounded border"
+                style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+              >
+                <input
+                  type="number"
+                  step="any"
+                  value={ing.quantity ?? ""}
+                  onChange={(e) =>
+                    updateIngredientLocal(ing._key, {
+                      quantity: e.target.value === "" ? null : Number(e.target.value),
+                    })
+                  }
+                  placeholder="ilość"
+                  className="w-16 px-1.5 py-1 rounded border text-xs"
+                  style={inputStyle}
+                />
+                <input
+                  type="text"
+                  value={ing.unit ?? ""}
+                  onChange={(e) => updateIngredientLocal(ing._key, { unit: e.target.value || null })}
+                  placeholder="jedn."
+                  className="w-16 px-1.5 py-1 rounded border text-xs"
+                  style={inputStyle}
+                />
+                <input
+                  type="text"
+                  value={ing.name}
+                  onChange={(e) => updateIngredientLocal(ing._key, { name: e.target.value })}
+                  onBlur={(e) => {
+                    const raw = e.target.value;
+                    if (raw && ing.quantity == null && /\d/.test(raw)) {
+                      handleIngredientSmartPaste(ing._key, raw);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && idx === ingredients.length - 1) {
+                      e.preventDefault();
+                      addIngredient();
+                    }
+                  }}
+                  placeholder="nazwa składnika"
+                  className="flex-1 min-w-0 px-2 py-1 rounded border text-sm"
+                  style={inputStyle}
+                />
+                <input
+                  type="text"
+                  value={ing.note ?? ""}
+                  onChange={(e) => updateIngredientLocal(ing._key, { note: e.target.value || null })}
+                  placeholder="notka"
+                  className="w-28 px-1.5 py-1 rounded border text-xs"
+                  style={inputStyle}
+                />
+                <label className="text-xs flex items-center gap-1" style={{ color: "var(--text-muted)" }}>
+                  <input
+                    type="checkbox"
+                    checked={ing.isOptional ?? false}
+                    onChange={(e) => updateIngredientLocal(ing._key, { isOptional: e.target.checked })}
+                  />
+                  opc.
+                </label>
+                <button
+                  type="button"
+                  onClick={() => removeIngredient(ing._key)}
+                  aria-label="Usuń składnik"
+                  style={{ color: "var(--accent-red)" }}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+              Przygotowanie
+            </h2>
+            <button
+              type="button"
+              onClick={addStep}
+              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded"
+              style={{ color: "var(--accent-orange)" }}
+            >
+              <Plus size={12} /> Dodaj krok
+            </button>
+          </div>
+          <div className="flex flex-col gap-2">
+            {steps.map((s, idx) => (
+              <div
+                key={s._key}
+                className="flex flex-col gap-1.5 p-2 rounded border"
+                style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
+                    style={{ backgroundColor: "var(--bg-elevated)", color: "var(--accent-orange)" }}
+                  >
+                    {idx + 1}
+                  </span>
+                  <span className="text-xs" style={{ color: "var(--text-muted)" }}>Krok</span>
+                  <button
+                    type="button"
+                    onClick={() => removeStep(s._key)}
+                    aria-label="Usuń krok"
+                    className="ml-auto"
+                    style={{ color: "var(--accent-red)" }}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+                <textarea
+                  value={s.text}
+                  onChange={(e) => updateStepLocal(s._key, { text: e.target.value })}
+                  placeholder="Opisz krok…"
+                  rows={2}
+                  className="w-full px-2 py-1.5 rounded border text-sm resize-y"
+                  style={inputStyle}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                      e.preventDefault();
+                      addStep();
+                    }
+                  }}
+                />
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-1 text-xs" style={{ color: "var(--text-muted)" }}>
+                    Timer (min):
+                    <input
+                      type="number"
+                      min={0}
+                      value={s.durationMin ?? ""}
+                      onChange={(e) =>
+                        updateStepLocal(s._key, {
+                          durationMin: e.target.value === "" ? null : Number(e.target.value),
+                        })
+                      }
+                      className="w-16 px-1.5 py-0.5 rounded border text-xs"
+                      style={inputStyle}
+                    />
+                  </label>
+                  <label className="flex items-center gap-1 text-xs" style={{ color: "var(--text-muted)" }}>
+                    Temp:
+                    <input
+                      type="text"
+                      value={s.temperature ?? ""}
+                      onChange={(e) => updateStepLocal(s._key, { temperature: e.target.value || null })}
+                      placeholder="180°C"
+                      className="w-20 px-1.5 py-0.5 rounded border text-xs"
+                      style={inputStyle}
+                    />
+                  </label>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <Field label="Notatki kucharza">
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={4}
+            placeholder="np. Najlepiej z guanciale, pieprz świeżo mielony."
+            className="w-full px-3 py-2 rounded border text-sm resize-y"
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  backgroundColor: "var(--bg-elevated)",
+  borderColor: "var(--border)",
+  color: "var(--text-primary)",
+};

--- a/worldofmag/src/components/kitchen/recipes/RecipeFilters.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeFilters.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { X } from "lucide-react";
+import { MEAL_TYPE_LABELS } from "@/types/kitchen";
+import type { MealType } from "@/types/kitchen";
+import type { Tag } from "@prisma/client";
+
+export interface RecipeFilterState {
+  cuisine: string | null;
+  mealType: MealType | null;
+  tagIds: string[];
+  maxMinutes: number | null;
+  cookbookId: string | null;
+}
+
+interface RecipeFiltersProps {
+  state: RecipeFilterState;
+  onChange: (next: RecipeFilterState) => void;
+  cuisines: string[];
+  tags: Tag[];
+  cookbooks: Array<{ id: string; name: string; emoji: string }>;
+}
+
+const MAX_MINUTES_PRESETS: Array<{ label: string; value: number }> = [
+  { label: "≤15 min", value: 15 },
+  { label: "≤30 min", value: 30 },
+  { label: "≤60 min", value: 60 },
+];
+
+export function RecipeFilters({ state, onChange, cuisines, tags, cookbooks }: RecipeFiltersProps) {
+  const activeCount =
+    (state.cuisine ? 1 : 0) +
+    (state.mealType ? 1 : 0) +
+    state.tagIds.length +
+    (state.maxMinutes != null ? 1 : 0) +
+    (state.cookbookId ? 1 : 0);
+
+  function toggleTag(id: string) {
+    const next = state.tagIds.includes(id)
+      ? state.tagIds.filter((t) => t !== id)
+      : [...state.tagIds, id];
+    onChange({ ...state, tagIds: next });
+  }
+
+  function clearAll() {
+    onChange({ cuisine: null, mealType: null, tagIds: [], maxMinutes: null, cookbookId: null });
+  }
+
+  return (
+    <div className="flex flex-col gap-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        {cuisines.length > 0 ? (
+          <select
+            value={state.cuisine ?? ""}
+            onChange={(e) => onChange({ ...state, cuisine: e.target.value || null })}
+            className="px-2 py-1 rounded border text-xs"
+            style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+          >
+            <option value="">Kuchnia: dowolna</option>
+            {cuisines.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        ) : null}
+
+        <select
+          value={state.mealType ?? ""}
+          onChange={(e) => onChange({ ...state, mealType: (e.target.value || null) as MealType | null })}
+          className="px-2 py-1 rounded border text-xs"
+          style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+        >
+          <option value="">Posiłek: dowolny</option>
+          {(Object.keys(MEAL_TYPE_LABELS) as MealType[]).map((mt) => (
+            <option key={mt} value={mt}>{MEAL_TYPE_LABELS[mt]}</option>
+          ))}
+        </select>
+
+        {cookbooks.length > 0 ? (
+          <select
+            value={state.cookbookId ?? ""}
+            onChange={(e) => onChange({ ...state, cookbookId: e.target.value || null })}
+            className="px-2 py-1 rounded border text-xs"
+            style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+          >
+            <option value="">Książka: dowolna</option>
+            {cookbooks.map((cb) => (
+              <option key={cb.id} value={cb.id}>{cb.emoji} {cb.name}</option>
+            ))}
+          </select>
+        ) : null}
+
+        <div className="flex items-center gap-1">
+          {MAX_MINUTES_PRESETS.map(({ label, value }) => {
+            const isActive = state.maxMinutes === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onChange({ ...state, maxMinutes: isActive ? null : value })}
+                className="px-2 py-1 rounded text-xs"
+                style={{
+                  backgroundColor: isActive ? "var(--accent-orange)" : "var(--bg-surface)",
+                  color: isActive ? "#0d0d0d" : "var(--text-secondary)",
+                  border: "1px solid var(--border)",
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
+        {activeCount > 0 ? (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs"
+            style={{ color: "var(--text-muted)" }}
+          >
+            <X size={12} /> Wyczyść filtry ({activeCount})
+          </button>
+        ) : null}
+      </div>
+
+      {tags.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag) => {
+            const isActive = state.tagIds.includes(tag.id);
+            return (
+              <button
+                key={tag.id}
+                type="button"
+                onClick={() => toggleTag(tag.id)}
+                className="px-2 py-0.5 rounded text-[11px]"
+                style={{
+                  backgroundColor: isActive ? "var(--accent-orange)" : (tag.color ?? "var(--bg-elevated)"),
+                  color: isActive ? "#0d0d0d" : "var(--text-secondary)",
+                }}
+              >
+                {tag.name}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/RecipeList.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeList.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Plus, Search, ChefHat } from "lucide-react";
+import { RecipeCard } from "./RecipeCard";
+import { RecipeFilters, type RecipeFilterState } from "./RecipeFilters";
+import type { RecipeListItem, MealType } from "@/types/kitchen";
+import type { Tag } from "@prisma/client";
+
+interface RecipeListProps {
+  recipes: RecipeListItem[];
+  tags: Tag[];
+  cookbooks: Array<{ id: string; name: string; emoji: string }>;
+}
+
+const EMPTY_FILTERS: RecipeFilterState = {
+  cuisine: null,
+  mealType: null,
+  tagIds: [],
+  maxMinutes: null,
+  cookbookId: null,
+};
+
+export function RecipeList({ recipes, tags, cookbooks }: RecipeListProps) {
+  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState<RecipeFilterState>(EMPTY_FILTERS);
+
+  const cuisines = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of recipes) if (r.cuisine) set.add(r.cuisine);
+    return Array.from(set).sort();
+  }, [recipes]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return recipes.filter((r) => {
+      if (q) {
+        const inText =
+          r.title.toLowerCase().includes(q) ||
+          (r.description?.toLowerCase().includes(q) ?? false) ||
+          (r.cuisine?.toLowerCase().includes(q) ?? false) ||
+          r.tags.some(({ tag }) => tag.name.toLowerCase().includes(q));
+        if (!inText) return false;
+      }
+      if (filters.cuisine && r.cuisine !== filters.cuisine) return false;
+      if (filters.mealType && r.mealType !== filters.mealType) return false;
+      if (filters.cookbookId && r.cookbookId !== filters.cookbookId) return false;
+      if (filters.maxMinutes != null) {
+        const total = (r.prepMinutes ?? 0) + (r.cookMinutes ?? 0);
+        if (total > filters.maxMinutes) return false;
+      }
+      if (filters.tagIds.length > 0) {
+        const rTagIds = new Set(r.tags.map(({ tag }) => tag.id));
+        for (const tid of filters.tagIds) if (!rTagIds.has(tid)) return false;
+      }
+      return true;
+    });
+  }, [recipes, search, filters]);
+
+  if (recipes.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-4 flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 flex-1 px-3 py-2 rounded border"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-surface)" }}
+        >
+          <Search size={14} style={{ color: "var(--text-muted)" }} />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Szukaj przepisów…"
+            className="flex-1 bg-transparent border-none outline-none text-sm"
+            style={{ color: "var(--text-primary)" }}
+          />
+        </div>
+        <Link
+          href="/kitchen/recipes/new"
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded text-sm whitespace-nowrap"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Plus size={16} /> Nowy
+        </Link>
+      </div>
+
+      <RecipeFilters
+        state={filters}
+        onChange={setFilters}
+        cuisines={cuisines}
+        tags={tags}
+        cookbooks={cookbooks}
+      />
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-10 text-sm" style={{ color: "var(--text-muted)" }}>
+          Brak przepisów spełniających filtry.
+        </div>
+      ) : (
+        <div
+          className="grid gap-3"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}
+        >
+          {filtered.map((r) => (
+            <RecipeCard key={r.id} recipe={r} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
+      <ChefHat size={48} style={{ color: "var(--text-muted)" }} />
+      <h2 className="mt-4 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        Brak przepisów
+      </h2>
+      <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
+        Zacznij od stworzenia swojego pierwszego przepisu. Możesz dodać składniki, kroki, czas i porcje, a potem jednym kliknięciem wygenerować listę zakupów.
+      </p>
+      <Link
+        href="/kitchen/recipes/new"
+        className="mt-6 inline-flex items-center gap-1.5 px-4 py-2 rounded text-sm"
+        style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+      >
+        <Plus size={16} /> Dodaj pierwszy przepis
+      </Link>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/RecipeList.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeList.tsx
@@ -2,16 +2,18 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, Search, ChefHat } from "lucide-react";
+import { Plus, Search, ChefHat, Globe, ChevronDown } from "lucide-react";
 import { RecipeCard } from "./RecipeCard";
 import { RecipeFilters, type RecipeFilterState } from "./RecipeFilters";
-import type { RecipeListItem, MealType } from "@/types/kitchen";
+import { ImportFromUrlDialog } from "./ImportFromUrlDialog";
+import type { RecipeListItem } from "@/types/kitchen";
 import type { Tag } from "@prisma/client";
 
 interface RecipeListProps {
   recipes: RecipeListItem[];
   tags: Tag[];
   cookbooks: Array<{ id: string; name: string; emoji: string }>;
+  hasAI?: boolean;
 }
 
 const EMPTY_FILTERS: RecipeFilterState = {
@@ -22,9 +24,11 @@ const EMPTY_FILTERS: RecipeFilterState = {
   cookbookId: null,
 };
 
-export function RecipeList({ recipes, tags, cookbooks }: RecipeListProps) {
+export function RecipeList({ recipes, tags, cookbooks, hasAI }: RecipeListProps) {
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState<RecipeFilterState>(EMPTY_FILTERS);
+  const [importOpen, setImportOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const cuisines = useMemo(() => {
     const set = new Set<string>();
@@ -59,7 +63,12 @@ export function RecipeList({ recipes, tags, cookbooks }: RecipeListProps) {
   }, [recipes, search, filters]);
 
   if (recipes.length === 0) {
-    return <EmptyState />;
+    return (
+      <>
+        <EmptyState hasAI={hasAI} onImportUrl={() => setImportOpen(true)} />
+        <ImportFromUrlDialog open={importOpen} onClose={() => setImportOpen(false)} />
+      </>
+    );
   }
 
   return (
@@ -79,13 +88,55 @@ export function RecipeList({ recipes, tags, cookbooks }: RecipeListProps) {
             style={{ color: "var(--text-primary)" }}
           />
         </div>
-        <Link
-          href="/kitchen/recipes/new"
-          className="inline-flex items-center gap-1.5 px-3 py-2 rounded text-sm whitespace-nowrap"
-          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
-        >
-          <Plus size={16} /> Nowy
-        </Link>
+        {hasAI ? (
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setMenuOpen((v) => !v)}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded text-sm whitespace-nowrap"
+              style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+            >
+              <Plus size={16} /> Nowy <ChevronDown size={12} />
+            </button>
+            {menuOpen ? (
+              <>
+                <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
+                <div
+                  className="absolute right-0 mt-1 w-52 z-50 rounded border shadow-lg"
+                  style={{ backgroundColor: "var(--bg-surface)", borderColor: "var(--border)" }}
+                >
+                  <Link
+                    href="/kitchen/recipes/new"
+                    className="flex items-center gap-2 px-3 py-2 text-sm"
+                    style={{ color: "var(--text-primary)" }}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <Plus size={14} /> Pusty przepis
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setImportOpen(true);
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    <Globe size={14} style={{ color: "var(--accent-purple)" }} /> Import z URL
+                  </button>
+                </div>
+              </>
+            ) : null}
+          </div>
+        ) : (
+          <Link
+            href="/kitchen/recipes/new"
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded text-sm whitespace-nowrap"
+            style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+          >
+            <Plus size={16} /> Nowy
+          </Link>
+        )}
       </div>
 
       <RecipeFilters
@@ -110,11 +161,13 @@ export function RecipeList({ recipes, tags, cookbooks }: RecipeListProps) {
           ))}
         </div>
       )}
+
+      <ImportFromUrlDialog open={importOpen} onClose={() => setImportOpen(false)} />
     </div>
   );
 }
 
-function EmptyState() {
+function EmptyState({ hasAI, onImportUrl }: { hasAI?: boolean; onImportUrl: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center h-full px-6 py-16 text-center">
       <ChefHat size={48} style={{ color: "var(--text-muted)" }} />
@@ -124,13 +177,25 @@ function EmptyState() {
       <p className="mt-2 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
         Zacznij od stworzenia swojego pierwszego przepisu. Możesz dodać składniki, kroki, czas i porcje, a potem jednym kliknięciem wygenerować listę zakupów.
       </p>
-      <Link
-        href="/kitchen/recipes/new"
-        className="mt-6 inline-flex items-center gap-1.5 px-4 py-2 rounded text-sm"
-        style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
-      >
-        <Plus size={16} /> Dodaj pierwszy przepis
-      </Link>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+        <Link
+          href="/kitchen/recipes/new"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <Plus size={16} /> Dodaj pierwszy przepis
+        </Link>
+        {hasAI ? (
+          <button
+            type="button"
+            onClick={onImportUrl}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded border text-sm"
+            style={{ borderColor: "var(--accent-purple)", color: "var(--accent-purple)" }}
+          >
+            <Globe size={14} /> Import z URL
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/worldofmag/src/components/kitchen/recipes/RecipeView.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeView.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { ArrowLeft, Clock, Users, Pencil, ShoppingCart, CheckCircle2, ChefHat, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
+import { ShopForRecipeDialog } from "./ShopForRecipeDialog";
+import { useToast } from "@/components/ui/Toast";
+import { markRecipeCooked, deleteRecipe } from "@/actions/recipes";
+import type { RecipeFull } from "@/types/kitchen";
+import { DIFFICULTY_LABELS, MEAL_TYPE_LABELS } from "@/types/kitchen";
+
+interface RecipeViewProps {
+  recipe: RecipeFull;
+  lists: Array<{ id: string; name: string }>;
+  canEdit: boolean;
+}
+
+function scaleQuantity(qty: number | null, factor: number): number | null {
+  if (qty == null) return null;
+  return Math.round(qty * factor * 100) / 100;
+}
+
+export function RecipeView({ recipe, lists, canEdit }: RecipeViewProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [servings, setServings] = useState(recipe.servings);
+  const [shopOpen, setShopOpen] = useState(false);
+  const [pendingDelete, startDelete] = useTransition();
+  const [pendingCook, startCook] = useTransition();
+
+  const scale = useMemo(
+    () => (recipe.servings > 0 ? servings / recipe.servings : 1),
+    [servings, recipe.servings]
+  );
+
+  const totalMins = (recipe.prepMinutes ?? 0) + (recipe.cookMinutes ?? 0);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, typeof recipe.ingredients>();
+    for (const ing of recipe.ingredients) {
+      const key = ing.groupName ?? "";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(ing);
+    }
+    return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [recipe.ingredients]);
+
+  function handleDelete() {
+    if (!confirm("Usunąć przepis? Tej operacji nie da się cofnąć.")) return;
+    startDelete(async () => {
+      try {
+        await deleteRecipe(recipe.id);
+        showToast("Przepis usunięty", "success");
+        router.push("/kitchen/recipes");
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd usuwania", "error");
+      }
+    });
+  }
+
+  function handleCooked() {
+    startCook(async () => {
+      try {
+        await markRecipeCooked(recipe.id, servings);
+        showToast(`Zaznaczono jako ugotowane (${servings} porcji)`, "success");
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd", "error");
+      }
+    });
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-4 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-3">
+        <Link
+          href="/kitchen/recipes"
+          className="inline-flex items-center gap-1 text-sm"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft size={14} /> Przepisy
+        </Link>
+        <div className="flex items-center gap-1">
+          {canEdit ? (
+            <Link
+              href={`/kitchen/recipes/${recipe.slug}/edit`}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded text-sm"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              <Pencil size={14} /> Edytuj
+            </Link>
+          ) : null}
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={pendingDelete}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded text-sm disabled:opacity-50"
+              style={{ color: "var(--accent-red)" }}
+            >
+              <Trash2 size={14} /> Usuń
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold" style={{ color: "var(--text-primary)" }}>
+          {recipe.title}
+        </h1>
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs" style={{ color: "var(--text-muted)" }}>
+          {recipe.cuisine ? <span>{recipe.cuisine}</span> : null}
+          {recipe.mealType ? <span>· {MEAL_TYPE_LABELS[recipe.mealType as keyof typeof MEAL_TYPE_LABELS] ?? recipe.mealType}</span> : null}
+          {totalMins > 0 ? (
+            <span className="inline-flex items-center gap-1">
+              <Clock size={11} /> {totalMins} min
+            </span>
+          ) : null}
+          <span>· {DIFFICULTY_LABELS[recipe.difficulty as keyof typeof DIFFICULTY_LABELS] ?? recipe.difficulty}</span>
+          {recipe.cookCount > 0 ? <span>· ugotowano {recipe.cookCount}×</span> : null}
+        </div>
+        {recipe.description ? (
+          <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+            {recipe.description}
+          </p>
+        ) : null}
+      </header>
+
+      {recipe.coverImageUrl ? (
+        <div
+          className="w-full mb-4 rounded overflow-hidden border"
+          style={{
+            aspectRatio: "16 / 9",
+            backgroundImage: `url(${recipe.coverImageUrl})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            borderColor: "var(--border)",
+          }}
+        />
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2 mb-5">
+        <ServingSelector value={servings} onChange={setServings} label="Porcje" />
+        <button
+          type="button"
+          onClick={() => setShopOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm"
+          style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+        >
+          <ShoppingCart size={14} /> Do listy zakupów
+        </button>
+        <button
+          type="button"
+          onClick={handleCooked}
+          disabled={pendingCook}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm border disabled:opacity-50"
+          style={{ borderColor: "var(--border)", color: "var(--text-primary)" }}
+        >
+          <CheckCircle2 size={14} /> Ugotowałem
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-[280px,1fr] gap-6">
+        <section>
+          <h2 className="text-sm font-semibold mb-2 uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+            Składniki
+          </h2>
+          {recipe.ingredients.length === 0 ? (
+            <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+              Brak składników.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {grouped.map(([group, items]) => (
+                <div key={group}>
+                  {group ? (
+                    <h3 className="text-xs font-semibold uppercase mt-1 mb-1" style={{ color: "var(--text-secondary)" }}>
+                      {group}
+                    </h3>
+                  ) : null}
+                  <ul className="flex flex-col gap-1">
+                    {items.map((ing) => {
+                      const qty = scaleQuantity(ing.quantity, scale);
+                      return (
+                        <li key={ing.id} className="text-sm" style={{ color: "var(--text-primary)" }}>
+                          {qty != null ? <span className="tabular-nums">{qty}</span> : null}
+                          {qty != null && ing.unit ? <span>{` ${ing.unit}`}</span> : null}
+                          {qty != null ? " " : ""}
+                          <span>{ing.name}</span>
+                          {ing.note ? (
+                            <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
+                              — {ing.note}
+                            </span>
+                          ) : null}
+                          {ing.isOptional ? (
+                            <span className="ml-1 text-[10px]" style={{ color: "var(--text-muted)" }}>
+                              (opc.)
+                            </span>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold mb-2 uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+            Przygotowanie
+          </h2>
+          {recipe.steps.length === 0 ? (
+            <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+              Brak kroków.
+            </p>
+          ) : (
+            <ol className="flex flex-col gap-3">
+              {recipe.steps.map((step, idx) => (
+                <li key={step.id} className="flex gap-3 text-sm">
+                  <span
+                    className="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold"
+                    style={{ backgroundColor: "var(--bg-elevated)", color: "var(--accent-orange)" }}
+                  >
+                    {idx + 1}
+                  </span>
+                  <div className="flex-1 flex flex-col gap-1">
+                    <p style={{ color: "var(--text-primary)", whiteSpace: "pre-wrap" }}>{step.text}</p>
+                    {(step.durationMin || step.temperature) ? (
+                      <div className="flex items-center gap-3 text-xs" style={{ color: "var(--text-muted)" }}>
+                        {step.durationMin ? <span>⏲ {step.durationMin} min</span> : null}
+                        {step.temperature ? <span>🌡 {step.temperature}</span> : null}
+                      </div>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      </div>
+
+      {recipe.notes && recipe.notes.trim() ? (
+        <section className="mt-6">
+          <h2 className="text-sm font-semibold mb-2 uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+            Notatki kucharza
+          </h2>
+          <p className="text-sm whitespace-pre-wrap" style={{ color: "var(--text-secondary)" }}>
+            {recipe.notes}
+          </p>
+        </section>
+      ) : null}
+
+      {recipe.tags.length > 0 ? (
+        <div className="mt-6 flex flex-wrap gap-1">
+          {recipe.tags.map(({ tag }) => (
+            <span
+              key={tag.id}
+              className="text-[11px] px-2 py-0.5 rounded"
+              style={{ backgroundColor: tag.color ?? "var(--bg-elevated)", color: "var(--text-secondary)" }}
+            >
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <ShopForRecipeDialog
+        recipe={recipe}
+        lists={lists}
+        open={shopOpen}
+        onClose={() => setShopOpen(false)}
+        defaultServings={servings}
+      />
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/recipes/RecipeView.tsx
+++ b/worldofmag/src/components/kitchen/recipes/RecipeView.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
-import { ArrowLeft, Clock, Users, Pencil, ShoppingCart, CheckCircle2, ChefHat, Trash2 } from "lucide-react";
+import { ArrowLeft, Clock, Users, Pencil, ShoppingCart, CheckCircle2, Trash2, Play } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
 import { ShopForRecipeDialog } from "./ShopForRecipeDialog";
@@ -142,6 +142,15 @@ export function RecipeView({ recipe, lists, canEdit }: RecipeViewProps) {
 
       <div className="flex flex-wrap items-center gap-2 mb-5">
         <ServingSelector value={servings} onChange={setServings} label="Porcje" />
+        {recipe.steps.length > 0 ? (
+          <Link
+            href={`/kitchen/recipes/${recipe.slug}/cook`}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm"
+            style={{ backgroundColor: "#0d0d0d", color: "var(--accent-orange)", border: "1px solid var(--accent-orange)" }}
+          >
+            <Play size={14} /> Cook Mode
+          </Link>
+        ) : null}
         <button
           type="button"
           onClick={() => setShopOpen(true)}

--- a/worldofmag/src/components/kitchen/recipes/ShopForRecipeDialog.tsx
+++ b/worldofmag/src/components/kitchen/recipes/ShopForRecipeDialog.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { X, ShoppingCart } from "lucide-react";
+import { shopForRecipe } from "@/actions/recipes";
+import { ServingSelector } from "@/components/kitchen/shared/ServingSelector";
+import { useToast } from "@/components/ui/Toast";
+import type { RecipeFull } from "@/types/kitchen";
+
+interface ShoppingListOption {
+  id: string;
+  name: string;
+}
+
+interface ShopForRecipeDialogProps {
+  recipe: RecipeFull;
+  lists: ShoppingListOption[];
+  open: boolean;
+  onClose: () => void;
+  defaultServings: number;
+}
+
+export function ShopForRecipeDialog({
+  recipe,
+  lists,
+  open,
+  onClose,
+  defaultServings,
+}: ShopForRecipeDialogProps) {
+  const [listId, setListId] = useState<string>(lists[0]?.id ?? "");
+  const [servings, setServings] = useState(defaultServings);
+  const [skipPantry, setSkipPantry] = useState(true);
+  const [skipOptional, setSkipOptional] = useState(false);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [submitting, startTransition] = useTransition();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (open) {
+      setServings(defaultServings);
+      setListId(lists[0]?.id ?? "");
+      setExcluded(new Set());
+    }
+  }, [open, defaultServings, lists]);
+
+  const includedCount = useMemo(() => {
+    return recipe.ingredients.filter((ing) => {
+      if (excluded.has(ing.id)) return false;
+      if (skipOptional && ing.isOptional) return false;
+      return true;
+    }).length;
+  }, [recipe.ingredients, excluded, skipOptional]);
+
+  if (!open) return null;
+
+  function toggleExclude(id: string) {
+    setExcluded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function handleConfirm() {
+    if (!listId) {
+      showToast("Wybierz listę docelową", "error");
+      return;
+    }
+    const overrides = Array.from(excluded).map((id) => ({ ingredientId: id, include: false }));
+    startTransition(async () => {
+      try {
+        const result = await shopForRecipe({
+          recipeId: recipe.id,
+          listId,
+          servings,
+          skipPantry,
+          skipOptional,
+          ingredientOverrides: overrides,
+        });
+        showToast(
+          `Dodano ${result.addedItems.length} pozycji${
+            result.skippedFromPantry.length > 0
+              ? ` (${result.skippedFromPantry.length} w spiżarni)`
+              : ""
+          }`,
+          "success"
+        );
+        onClose();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : "Błąd dodawania", "error");
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:w-[500px] md:rounded border max-h-[90vh] overflow-y-auto"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          borderColor: "var(--border)",
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "var(--border)" }}>
+          <h3 className="text-base font-semibold flex items-center gap-2" style={{ color: "var(--text-primary)" }}>
+            <ShoppingCart size={16} style={{ color: "var(--accent-orange)" }} />
+            Dodaj do listy zakupów
+          </h3>
+          <button onClick={onClose} aria-label="Zamknij" style={{ color: "var(--text-muted)" }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          {lists.length === 0 ? (
+            <p className="text-sm" style={{ color: "var(--accent-amber)" }}>
+              Nie masz żadnej listy zakupów. Utwórz najpierw listę w module Zakupy.
+            </p>
+          ) : (
+            <label className="flex flex-col gap-1 text-sm">
+              <span style={{ color: "var(--text-secondary)" }}>Lista docelowa</span>
+              <select
+                value={listId}
+                onChange={(e) => setListId(e.target.value)}
+                className="px-2 py-1.5 rounded border text-sm"
+                style={{ backgroundColor: "var(--bg-elevated)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+              >
+                {lists.map((l) => (
+                  <option key={l.id} value={l.id}>{l.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <div className="flex items-center justify-between">
+            <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Porcje</span>
+            <ServingSelector value={servings} onChange={setServings} />
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={skipPantry} onChange={(e) => setSkipPantry(e.target.checked)} />
+            <span style={{ color: "var(--text-primary)" }}>Pomiń to co mam w spiżarni</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={skipOptional} onChange={(e) => setSkipOptional(e.target.checked)} />
+            <span style={{ color: "var(--text-primary)" }}>Pomiń składniki opcjonalne</span>
+          </label>
+
+          <div className="flex flex-col gap-1 mt-1">
+            <span className="text-xs uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+              Składniki ({includedCount} aktywne)
+            </span>
+            <ul className="flex flex-col gap-1 max-h-60 overflow-y-auto">
+              {recipe.ingredients.length === 0 ? (
+                <li className="text-sm" style={{ color: "var(--text-muted)" }}>
+                  Ten przepis nie ma jeszcze składników.
+                </li>
+              ) : null}
+              {recipe.ingredients.map((ing) => {
+                const checked = !excluded.has(ing.id) && !(skipOptional && ing.isOptional);
+                const scale = recipe.servings > 0 ? servings / recipe.servings : 1;
+                const scaledQty = ing.quantity != null ? Math.round(ing.quantity * scale * 100) / 100 : null;
+                return (
+                  <li key={ing.id} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={skipOptional && ing.isOptional}
+                      onChange={() => toggleExclude(ing.id)}
+                    />
+                    <span style={{ color: checked ? "var(--text-primary)" : "var(--text-muted)" }}>
+                      {scaledQty != null ? `${scaledQty}${ing.unit ? ` ${ing.unit}` : ""} ` : ""}
+                      {ing.name}
+                      {ing.isOptional ? (
+                        <span className="ml-1 text-[10px]" style={{ color: "var(--text-muted)" }}>
+                          (opc.)
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-3 border-t" style={{ borderColor: "var(--border)" }}>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded text-sm"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            Anuluj
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={submitting || lists.length === 0 || includedCount === 0}
+            className="px-3 py-1.5 rounded text-sm disabled:opacity-50"
+            style={{ backgroundColor: "var(--accent-orange)", color: "#0d0d0d" }}
+          >
+            {submitting ? "Dodaję…" : `Dodaj ${includedCount} ${includedCount === 1 ? "pozycję" : "pozycji"}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/worldofmag/src/components/kitchen/shared/ServingSelector.tsx
+++ b/worldofmag/src/components/kitchen/shared/ServingSelector.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Minus, Plus } from "lucide-react";
+
+interface ServingSelectorProps {
+  value: number;
+  onChange: (next: number) => void;
+  min?: number;
+  max?: number;
+  className?: string;
+  label?: string;
+}
+
+export function ServingSelector({ value, onChange, min = 1, max = 99, className, label }: ServingSelectorProps) {
+  return (
+    <div
+      className={className}
+      style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+    >
+      {label ? (
+        <span className="text-xs" style={{ color: "var(--text-muted)" }}>{label}</span>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => onChange(Math.max(min, value - 1))}
+        className="w-7 h-7 rounded flex items-center justify-center"
+        style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+        aria-label="Zmniejsz porcje"
+      >
+        <Minus size={14} />
+      </button>
+      <span
+        className="px-2 text-sm font-medium tabular-nums"
+        style={{ color: "var(--text-primary)", minWidth: 28, textAlign: "center" }}
+      >
+        {value}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(Math.min(max, value + 1))}
+        className="w-7 h-7 rounded flex items-center justify-center"
+        style={{ backgroundColor: "var(--bg-elevated)", color: "var(--text-secondary)" }}
+        aria-label="Zwiększ porcje"
+      >
+        <Plus size={14} />
+      </button>
+    </div>
+  );
+}

--- a/worldofmag/src/components/shell/AppShell.tsx
+++ b/worldofmag/src/components/shell/AppShell.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu, X, Sparkles, ShoppingCart, Calendar, FileText, Briefcase, Settings, Mail, Shield, CheckSquare, Home, Map, Image, Lock, BookOpen } from "lucide-react";
+import { Menu, X, Sparkles, ShoppingCart, Calendar, FileText, Briefcase, Settings, Mail, Shield, CheckSquare, Home, Map, Image, Lock, BookOpen, ChefHat } from "lucide-react";
 import { ModuleSidebar } from "./ModuleSidebar";
 import { AICommandSheet } from "@/components/home/AICommandSheet";
 import { ToastProvider } from "@/components/ui/Toast";
@@ -22,6 +22,7 @@ const MODULES = [
   { id: "shopping",    label: "Zakupy",        icon: <ShoppingCart size={20} />, topBarIcon: <ShoppingCart size={16} />, color: "var(--accent-blue)",     href: "/shopping",    active: true,  exact: false },
   { id: "tasks",       label: "Zadania",       icon: <CheckSquare size={20} />,  topBarIcon: <CheckSquare size={16} />,  color: "var(--accent-green)",    href: "/tasks",       active: true,  exact: false },
   { id: "notes",       label: "Notatki",       icon: <FileText size={20} />,     topBarIcon: <FileText size={16} />,     color: "var(--accent-amber)",    href: "/notes",       active: true,  exact: false },
+  { id: "kitchen",     label: "Kuchnia",       icon: <ChefHat size={20} />,      topBarIcon: <ChefHat size={16} />,      color: "var(--accent-orange)",   href: "/kitchen",     active: true,  exact: false },
   { id: "calendar",    label: "Calendar",      icon: <Calendar size={20} />,     topBarIcon: <Calendar size={16} />,     color: "var(--text-muted)",      href: "/calendar",    active: false, exact: false },
   { id: "work",        label: "Work",          icon: <Briefcase size={20} />,    topBarIcon: <Briefcase size={16} />,    color: "var(--text-muted)",      href: "/work",        active: false, exact: false },
   { id: "settings",    label: "Ustawienia",    icon: null,                        topBarIcon: <Settings size={16} />,    color: "var(--text-secondary)",  href: "/settings",    active: false, exact: false },
@@ -137,6 +138,22 @@ export function AppShell({ children, invitationCount = 0, isAdmin = false, userR
                 <div className="mb-1">
                   {[{ href: "/notes/all", label: "Wszystkie" }, { href: "/notes/groups", label: "Grupy" }, { href: "/notes/tags", label: "Tagi" }].map(({ href, label }) => (
                     <MobileSub key={href} href={href} pathname={pathname} locked={isLocked("/notes")}>{label}</MobileSub>
+                  ))}
+                </div>
+              )}
+
+              <MobileItem href="/kitchen" pathname={pathname} locked={isLocked("/kitchen")}>
+                <ChefHat size={20} style={{ color: "var(--accent-orange)", flexShrink: 0 }} /><span>Kuchnia</span>
+              </MobileItem>
+              {pathname.startsWith("/kitchen") && (
+                <div className="mb-1">
+                  {[
+                    { href: "/kitchen/recipes",  label: "Przepisy" },
+                    { href: "/kitchen/plan",     label: "Plan" },
+                    { href: "/kitchen/pantry",   label: "Spiżarnia" },
+                    { href: "/kitchen/cookbooks", label: "Książki" },
+                  ].map(({ href, label }) => (
+                    <MobileSub key={href} href={href} pathname={pathname} locked={isLocked("/kitchen")}>{label}</MobileSub>
                   ))}
                 </div>
               )}

--- a/worldofmag/src/components/shell/ModuleSidebar.tsx
+++ b/worldofmag/src/components/shell/ModuleSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ShoppingCart, Calendar, FileText, Briefcase, Settings, Sparkles, Mail, Shield, CheckSquare, Home, FolderOpen, Tag, Map, Image, Lock, BookOpen } from "lucide-react";
+import { ShoppingCart, Calendar, FileText, Briefcase, Settings, Sparkles, Mail, Shield, CheckSquare, Home, FolderOpen, Tag, Map, Image, Lock, BookOpen, ChefHat, Package, BookMarked, CalendarDays } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { TasksSideNav } from "@/components/tasks/TasksSideNav";
 import { isPathLocked } from "@/lib/permissions";
@@ -135,6 +135,7 @@ export function ModuleSidebar({ invitationCount = 0, isAdmin = false, userRoles 
   const isShoppingActive = pathname.startsWith("/shopping");
   const isNotesActive = pathname.startsWith("/notes");
   const isTasksActive = pathname.startsWith("/tasks");
+  const isKitchenActive = pathname.startsWith("/kitchen");
 
   function isLocked(href: string): boolean {
     return isPathLocked(userPermissions, href);
@@ -193,6 +194,17 @@ export function ModuleSidebar({ invitationCount = 0, isAdmin = false, userRoles 
         {isTasksActive && (
           <div className="mb-1">
             <TasksSideNav />
+          </div>
+        )}
+
+        {/* Kitchen with sub-items */}
+        <NavItem href="/kitchen" label="Kuchnia" icon={<ChefHat size={18} />} pathname={pathname} iconColor="var(--accent-orange)" locked={isLocked("/kitchen")} />
+        {isKitchenActive && (
+          <div className="mb-1">
+            <NavSubItem href="/kitchen/recipes" label="Przepisy" icon={<BookMarked size={12} />} pathname={pathname} locked={isLocked("/kitchen")} />
+            <NavSubItem href="/kitchen/plan" label="Plan" icon={<CalendarDays size={12} />} pathname={pathname} locked={isLocked("/kitchen")} />
+            <NavSubItem href="/kitchen/pantry" label="Spiżarnia" icon={<Package size={12} />} pathname={pathname} locked={isLocked("/kitchen")} />
+            <NavSubItem href="/kitchen/cookbooks" label="Książki" icon={<BookOpen size={12} />} pathname={pathname} locked={isLocked("/kitchen")} />
           </div>
         )}
 

--- a/worldofmag/src/lib/kitchenDate.ts
+++ b/worldofmag/src/lib/kitchenDate.ts
@@ -1,0 +1,39 @@
+import { addDays, startOfWeek, endOfWeek, format, isSameDay } from "date-fns";
+import { pl } from "date-fns/locale";
+
+export const POLISH_WEEKDAY_SHORT = ["Pon", "Wt", "Śr", "Czw", "Pt", "Sob", "Nd"];
+
+export function getWeekStart(date: Date): Date {
+  return startOfWeek(date, { weekStartsOn: 1 });
+}
+
+export function getWeekEnd(date: Date): Date {
+  return endOfWeek(date, { weekStartsOn: 1 });
+}
+
+export function getWeekDays(date: Date): Date[] {
+  const start = getWeekStart(date);
+  return Array.from({ length: 7 }, (_, i) => addDays(start, i));
+}
+
+export function formatWeekRange(date: Date): string {
+  const start = getWeekStart(date);
+  const end = getWeekEnd(date);
+  return `${format(start, "d MMM", { locale: pl })} – ${format(end, "d MMM yyyy", { locale: pl })}`;
+}
+
+export function formatDayShort(date: Date): string {
+  return `${POLISH_WEEKDAY_SHORT[(date.getDay() + 6) % 7]} ${date.getDate()}`;
+}
+
+export function formatDayLong(date: Date): string {
+  return format(date, "EEEE, d MMMM", { locale: pl });
+}
+
+export function dateKey(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+export function isToday(date: Date): boolean {
+  return isSameDay(date, new Date());
+}

--- a/worldofmag/src/lib/llm-client.ts
+++ b/worldofmag/src/lib/llm-client.ts
@@ -65,4 +65,54 @@ export const llm = {
     execute: (intent: string, params: unknown) =>
       post<{ result?: string }>("/api/llm/home/execute", { intent, params }),
   },
+
+  kitchen: {
+    parseIngredients: (text: string) =>
+      post<{
+        ingredients?: Array<{
+          name: string;
+          quantity: number | null;
+          unit: string | null;
+          note: string | null;
+          isOptional: boolean;
+        }>;
+        error?: string;
+      }>("/api/llm/kitchen/parse-ingredients", { text }),
+
+    importFromUrl: (url: string) =>
+      post<{
+        recipe?: {
+          title: string;
+          description: string | null;
+          servings: number | null;
+          prepMinutes: number | null;
+          cookMinutes: number | null;
+          cuisine: string | null;
+          mealType: string | null;
+          coverImageUrl: string | null;
+          notes: string | null;
+          ingredients: Array<{
+            name: string;
+            quantity: number | null;
+            unit: string | null;
+            note: string | null;
+            isOptional: boolean;
+          }>;
+          steps: Array<{ text: string }>;
+        };
+        sourceUrl?: string;
+        error?: string;
+      }>("/api/llm/kitchen/import-url", { url }),
+
+    suggestFromPantry: () =>
+      post<{
+        suggestions?: Array<{
+          recipeId: string;
+          slug: string;
+          title: string;
+          reason: string;
+          matchedIngredients: string[];
+        }>;
+      }>("/api/llm/kitchen/suggest-from-pantry", {}),
+  },
 };

--- a/worldofmag/src/lib/permissions.ts
+++ b/worldofmag/src/lib/permissions.ts
@@ -5,9 +5,17 @@ export const PERMISSIONS = {
   SHOPPING:    "module.shopping",
   TASKS:       "module.tasks",
   NOTES:       "module.notes",
+  KITCHEN:     "module.kitchen",
   SETTINGS:    "module.settings",
   ADMIN:       "module.admin",
   INVITATIONS: "module.invitations",
+  // Kitchen sub-permissions
+  KITCHEN_RECIPE_CREATE: "kitchen.recipe.create",
+  KITCHEN_RECIPE_EDIT:   "kitchen.recipe.edit",
+  KITCHEN_RECIPE_DELETE: "kitchen.recipe.delete",
+  KITCHEN_MEALPLAN_EDIT: "kitchen.mealplan.edit",
+  KITCHEN_PANTRY_EDIT:   "kitchen.pantry.edit",
+  KITCHEN_AI:            "kitchen.ai",
 } as const
 
 export type PermissionSlug = typeof PERMISSIONS[keyof typeof PERMISSIONS]
@@ -22,6 +30,7 @@ export function permissionForPath(path: string): string | null {
   if (path.startsWith("/shopping")) return PERMISSIONS.SHOPPING
   if (path.startsWith("/tasks")) return PERMISSIONS.TASKS
   if (path.startsWith("/notes")) return PERMISSIONS.NOTES
+  if (path.startsWith("/kitchen")) return PERMISSIONS.KITCHEN
   if (path.startsWith("/settings")) return PERMISSIONS.SETTINGS
   if (path.startsWith("/admin")) return PERMISSIONS.ADMIN
   if (path.startsWith("/invitations")) return PERMISSIONS.INVITATIONS

--- a/worldofmag/src/types/kitchen.ts
+++ b/worldofmag/src/types/kitchen.ts
@@ -1,0 +1,132 @@
+import type {
+  Recipe as PrismaRecipe,
+  RecipeIngredient as PrismaRecipeIngredient,
+  RecipeStep as PrismaRecipeStep,
+  RecipeImage as PrismaRecipeImage,
+  Cookbook as PrismaCookbook,
+  MealPlanEntry as PrismaMealPlanEntry,
+  PantryItem as PrismaPantryItem,
+  Tag,
+  Product,
+} from "@prisma/client";
+
+export type MealSlot = "breakfast" | "lunch" | "dinner" | "snack";
+export type MealType = MealSlot | "dessert";
+export type Difficulty = "easy" | "medium" | "hard";
+export type MealStatus = "PLANNED" | "COOKED" | "SKIPPED";
+export type RecipeSource = "manual" | "url" | "ai" | "ocr" | "image";
+export type PantryLocation = "fridge" | "freezer" | "pantry" | "spice_rack" | "other";
+
+export const MEAL_SLOTS: MealSlot[] = ["breakfast", "lunch", "dinner", "snack"];
+
+export const MEAL_SLOT_LABELS: Record<MealSlot, string> = {
+  breakfast: "Śniadanie",
+  lunch: "Obiad",
+  dinner: "Kolacja",
+  snack: "Przekąska",
+};
+
+export const MEAL_TYPE_LABELS: Record<MealType, string> = {
+  breakfast: "Śniadanie",
+  lunch: "Obiad",
+  dinner: "Kolacja",
+  snack: "Przekąska",
+  dessert: "Deser",
+};
+
+export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
+  easy: "Łatwe",
+  medium: "Średnie",
+  hard: "Trudne",
+};
+
+export type Cookbook = PrismaCookbook;
+
+export type RecipeIngredient = PrismaRecipeIngredient & {
+  product?: Product | null;
+};
+
+export type RecipeStep = PrismaRecipeStep;
+
+export type RecipeImage = PrismaRecipeImage;
+
+export type RecipeListItem = Pick<
+  PrismaRecipe,
+  | "id"
+  | "title"
+  | "slug"
+  | "description"
+  | "coverImageUrl"
+  | "prepMinutes"
+  | "cookMinutes"
+  | "servings"
+  | "difficulty"
+  | "cuisine"
+  | "mealType"
+  | "cookCount"
+  | "lastCookedAt"
+  | "rating"
+  | "ownerId"
+  | "ownerTeamId"
+  | "cookbookId"
+  | "isPublic"
+  | "isArchived"
+  | "createdAt"
+  | "updatedAt"
+> & {
+  tags: Array<{ tag: Tag }>;
+};
+
+export type RecipeFull = PrismaRecipe & {
+  ingredients: RecipeIngredient[];
+  steps: RecipeStep[];
+  images: RecipeImage[];
+  tags: Array<{ tag: Tag }>;
+  cookbook: Cookbook | null;
+};
+
+export interface IngredientInput {
+  name: string;
+  productId?: string | null;
+  quantity?: number | null;
+  unit?: string | null;
+  groupName?: string | null;
+  note?: string | null;
+  isOptional?: boolean;
+  order?: number;
+}
+
+export interface StepInput {
+  text: string;
+  order?: number;
+  durationMin?: number | null;
+  temperature?: string | null;
+  imageUrl?: string | null;
+}
+
+export interface CreateRecipeInput {
+  title: string;
+  description?: string | null;
+  servings?: number;
+  prepMinutes?: number | null;
+  cookMinutes?: number | null;
+  difficulty?: Difficulty;
+  cuisine?: string | null;
+  mealType?: MealType | null;
+  coverImageUrl?: string | null;
+  notes?: string | null;
+  introMarkdown?: string | null;
+  cookbookId?: string | null;
+  ownerTeamId?: string | null;
+  tagIds?: string[];
+  ingredients?: IngredientInput[];
+  steps?: StepInput[];
+}
+
+export type UpdateRecipeInput = Partial<CreateRecipeInput>;
+
+export type MealPlanEntry = PrismaMealPlanEntry;
+
+export type PantryItem = PrismaPantryItem & {
+  product?: Product | null;
+};


### PR DESCRIPTION
- migracja 0023_kitchen_module: 10 nowych modeli (Recipe + składniki/kroki/zdjęcia/tagi/ratings, Cookbook, MealPlanEntry, PantryItem, ItemRecipeOrigin) + 7 nowych permissions seedowanych do USER/BETA_TESTER/ADMIN
- typy TS w src/types/kitchen.ts (MealSlot, Difficulty, RecipeListItem, RecipeFull, ...)
- routing /kitchen z layoutem i tabami (Przepisy/Plan/Spiżarnia/Książki), redirect / → /recipes
- placeholdery stron Recipes/Plan/Pantry/Cookbooks
- sidebar entry „Kuchnia" (ChefHat, --accent-orange) w AppShell i ModuleSidebar
- nowe tokeny CSS: --accent-orange, --kitchen-pantry/-expiring/-expired
- dependencies: @dnd-kit/core, @dnd-kit/sortable, date-fns

https://claude.ai/code/session_018EvqSKTqP4ruiro4FKAhki